### PR TITLE
Fix browser Sonos room/sessionId field separation

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -43,10 +43,11 @@ If your browser is older and recording does not work, update the browser first.
 2. When your browser asks for microphone access, choose **Allow**.
 3. In the **Settings** card at the top of the page, check that **Voice Service URL** matches the service address you were given.
 4. In **Access Token**, paste the voice access token you were given.
-5. If your household or project uses a room label, enter it in **Room Name (optional)**. Otherwise, leave it blank.
-6. Click **Save Settings**.
-7. Check the saved summary under the Settings card. It should show your service URL, room name if used, and a masked token.
-8. Wait for the status message to say the app is ready.
+5. If your setup uses OpenClaw conversation tracking, enter a value in **Session ID (optional)**.
+6. If your household or project uses Sonos playback, enter the speaker in **Sonos Room (optional)**.
+7. Click **Save Settings**.
+8. Check the saved summary under the Settings card. It should show your service URL, session ID and room if used, and a masked token.
+9. Wait for the status message to say the app is ready.
 
 ### Desktop mode
 
@@ -115,7 +116,7 @@ Use these only if replies should play through Sonos:
 - `SONOS_RELAY_TIMEOUT_MS`: timeout per relay attempt before trying the fallback relay
 - `SONOS_ROOM_DEFAULT`: fallback room name when a browser or desktop client does not send one
 
-If a household uses more than one Sonos room, users can enter a room name in the browser settings or the desktop client can send `VOICE_CLIENT_SONOS_ROOM`.
+If a household uses more than one Sonos room, users can enter a room name in the browser setting **Sonos Room (optional)** or the desktop client can send `VOICE_CLIENT_SONOS_ROOM`.
 
 ### Desktop client settings
 
@@ -253,9 +254,9 @@ Usually no. The main experience still runs in a browser, so most people only nee
 
 Yes. This version uses push-to-talk. Hold the button while speaking, then release it to send your request.
 
-### What does Room Name mean?
+### What do Session ID and Sonos Room mean?
 
-It is an optional label that can help keep a conversation tied to a room, device, or user flow. If you were not told to use one, you can leave it blank.
+**Session ID** is an optional conversation context label sent to OpenClaw. **Sonos Room** is the optional speaker target used for Sonos playback. If you were not told to use either value, you can leave both blank.
 
 ### Can I use the keyboard instead of pressing the button?
 

--- a/public/app.js
+++ b/public/app.js
@@ -3,6 +3,7 @@ const STORAGE_KEY = "openclawVoiceSettingsV1";
 const serviceUrlInput = document.querySelector("#serviceUrl");
 const tokenInput = document.querySelector("#token");
 const sessionIdInput = document.querySelector("#sessionId");
+const sonosRoomInput = document.querySelector("#sonosRoom");
 const apiPathInput = document.querySelector("#apiPath");
 const saveSettingsButton = document.querySelector("#saveSettings");
 const clearSettingsButton = document.querySelector("#clearSettings");
@@ -17,6 +18,7 @@ const settings = {
   serviceUrl: window.location.origin,
   token: "",
   sessionId: "",
+  sonosRoom: "",
   apiPath: "/api/voice/turn"
 };
 
@@ -73,13 +75,15 @@ function updateInputsFromSettings() {
   serviceUrlInput.value = settings.serviceUrl;
   tokenInput.value = settings.token;
   sessionIdInput.value = settings.sessionId;
+  sonosRoomInput.value = settings.sonosRoom;
   apiPathInput.value = settings.apiPath;
 }
 
 function updateSettingsSummary() {
   const maskedToken = settings.token ? `${"*".repeat(Math.min(settings.token.length, 8))}` : "not set";
-  const room = settings.sessionId || "not set";
-  settingsSummaryEl.textContent = `Server: ${settings.serviceUrl} | Token: ${maskedToken} | Room: ${room}`;
+  const sessionId = settings.sessionId || "not set";
+  const room = settings.sonosRoom || "not set";
+  settingsSummaryEl.textContent = `Server: ${settings.serviceUrl} | Token: ${maskedToken} | Session: ${sessionId} | Room: ${room}`;
 }
 
 function saveSettings() {
@@ -87,6 +91,7 @@ function saveSettings() {
     serviceUrl: serviceUrlInput.value.trim() || window.location.origin,
     token: tokenInput.value.trim(),
     sessionId: sessionIdInput.value.trim(),
+    sonosRoom: sonosRoomInput.value.trim(),
     apiPath: normalizeApiPath(apiPathInput.value)
   };
 
@@ -112,6 +117,7 @@ function saveSettings() {
     serviceUrl: parsedUrl.origin,
     token: next.token,
     sessionId: next.sessionId,
+    sonosRoom: next.sonosRoom,
     apiPath: next.apiPath
   });
 
@@ -134,6 +140,7 @@ function clearSettings() {
     serviceUrl: window.location.origin,
     token: "",
     sessionId: "",
+    sonosRoom: "",
     apiPath: "/api/voice/turn"
   });
   updateInputsFromSettings();
@@ -152,10 +159,13 @@ function loadSettings() {
 
   try {
     const parsed = JSON.parse(raw);
+    const hasSonosRoom = typeof parsed.sonosRoom === "string";
+    const legacyRoom = !hasSonosRoom && typeof parsed.sessionId === "string" ? parsed.sessionId : "";
     Object.assign(settings, {
       serviceUrl: typeof parsed.serviceUrl === "string" ? parsed.serviceUrl : window.location.origin,
       token: typeof parsed.token === "string" ? parsed.token : "",
-      sessionId: typeof parsed.sessionId === "string" ? parsed.sessionId : "",
+      sessionId: hasSonosRoom && typeof parsed.sessionId === "string" ? parsed.sessionId : "",
+      sonosRoom: hasSonosRoom ? parsed.sonosRoom : legacyRoom,
       apiPath: typeof parsed.apiPath === "string" ? normalizeApiPath(parsed.apiPath) : "/api/voice/turn"
     });
   } catch {
@@ -231,6 +241,7 @@ function extensionFromMimeType(mimeType, fallbackExtension) {
 async function postVoiceTurn(blob, filename) {
   const token = settings.token;
   const sessionId = settings.sessionId;
+  const sonosRoom = settings.sonosRoom;
 
   if (!token) {
     setStatus("Please save an access token before recording.", "error");
@@ -243,6 +254,9 @@ async function postVoiceTurn(blob, filename) {
   form.append("audio", blob, filename);
   if (sessionId) {
     form.append("sessionId", sessionId);
+  }
+  if (sonosRoom) {
+    form.append("sonosRoom", sonosRoom);
   }
 
   const response = await fetch(getVoiceTurnEndpoint(), {

--- a/public/index.html
+++ b/public/index.html
@@ -207,8 +207,14 @@
         </div>
 
         <div class="row">
-          <label for="sessionId">Room Name (optional)</label>
-          <input id="sessionId" type="text" placeholder="Kitchen, Office, Living Room..." autocomplete="off" />
+          <label for="sessionId">Session ID (optional)</label>
+          <input id="sessionId" type="text" placeholder="KitchenTablet, HallwayMic, ..." autocomplete="off" />
+          <p class="hint">Used for OpenClaw conversation context. This is not the Sonos room.</p>
+        </div>
+
+        <div class="row">
+          <label for="sonosRoom">Sonos Room (optional)</label>
+          <input id="sonosRoom" type="text" placeholder="Kitchen, Office, Living Room..." autocomplete="off" />
         </div>
 
         <details>

--- a/src/server.js
+++ b/src/server.js
@@ -491,7 +491,7 @@ app.post("/api/voice/turn", requireBearer, upload.single("audio"), async (req, r
     const sonos = await sendAudioToSonosRelay(
       synthesis.audio,
       spokenResponse,
-      req.body?.sonosRoom || req.body?.sessionId,
+      req.body?.sonosRoom,
       synthesis.audioMimeType
     );
 


### PR DESCRIPTION
## Summary
- Add a dedicated browser `sonosRoom` setting/input and send it separately from `sessionId` in voice turn requests.
- Remove the server-side fallback that treated `sessionId` as a Sonos room target.
- Update end-user docs to explain `Session ID` vs `Sonos Room` so room routing and session continuity stay distinct.

## Validation
- `node --check src/server.js`
- `node --check public/app.js`
- `node --check desktop/client.js`

Closes #2