### PR TITLE
docs: add Piper install/model/smoke-test guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,32 @@ Ambient mode still keeps manual Enter-triggered recording available in the termi
 
 Use Piper when you want local speech synthesis or a fallback when Edge TTS is unavailable.
 
-1. Install the Piper CLI and download a voice model on the machine running the server.
-2. Set `TTS_PROVIDER=piper` to force Piper, or set `TTS_PROVIDER=edge` plus `TTS_FALLBACK_PROVIDER=piper` to keep Edge as the first choice.
-3. Set `PIPER_MODEL_PATH` to the absolute path of the downloaded `.onnx` voice model.
-4. Optional: set `PIPER_BIN` if the executable is not available as `piper` on your `PATH`.
-5. Optional: tune `PIPER_SPEAKER_ID`, `PIPER_LENGTH_SCALE`, `PIPER_NOISE_SCALE`, `PIPER_NOISE_W`, and `PIPER_SENTENCE_SILENCE` for your chosen voice.
+1. Install Piper from the official release source: <https://github.com/rhasspy/piper/releases>.
+2. Download a voice model (`.onnx`) from Piper voices (for example: <https://huggingface.co/rhasspy/piper-voices>). Typical model filenames look like `en_US-lessac-medium.onnx`.
+3. Set provider + model variables:
 
-Important: if Piper is your primary provider, or your Edge provider falls back to Piper, the service needs a valid `PIPER_MODEL_PATH` before it can synthesize responses.
+   ```bash
+   TTS_PROVIDER=piper
+   PIPER_BIN=/usr/local/bin/piper
+   PIPER_MODEL_PATH=/opt/piper/en_US-lessac-medium.onnx
+   ```
+
+   Notes:
+
+   - This repo uses `PIPER_BIN` for the executable path (same idea as `PIPER_EXECUTABLE` in some Piper guides).
+   - If you prefer Edge first, keep `TTS_PROVIDER=edge` and set `TTS_FALLBACK_PROVIDER=piper`.
+
+4. Optional: tune `PIPER_SPEAKER_ID`, `PIPER_LENGTH_SCALE`, `PIPER_NOISE_SCALE`, `PIPER_NOISE_W`, and `PIPER_SENTENCE_SILENCE` for your chosen voice.
+5. Run a smoke test directly against Piper:
+
+   ```bash
+   echo "Piper smoke test" | "$PIPER_BIN" --model "$PIPER_MODEL_PATH" --output_file /tmp/piper-smoke.wav
+   ls -lh /tmp/piper-smoke.wav
+   ```
+
+   If `/tmp/piper-smoke.wav` exists and is non-zero size, Piper + model path are valid.
+
+Important: Piper outputs WAV (`audio/wav`). Edge TTS outputs MP3 (`audio/mpeg`). If Piper is your primary provider, or your Edge provider falls back to Piper, the service needs a valid `PIPER_MODEL_PATH` before it can synthesize responses.
 
 ### Sonos Pi relay migration
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -159,6 +159,20 @@ Phase 4 adds local Piper as a TTS option and fallback:
 
 If administrators want local-only speech output, they should set `TTS_PROVIDER=piper`, install the Piper CLI on the server, and point `PIPER_MODEL_PATH` at a downloaded voice model.
 
+Quick Piper operator checks:
+
+- Install source: <https://github.com/rhasspy/piper/releases>
+- Voice models: <https://huggingface.co/rhasspy/piper-voices> (for example `en_US-lessac-medium.onnx`)
+- This project uses `PIPER_BIN` as the executable env var (equivalent to `PIPER_EXECUTABLE` in some external guides)
+- Smoke test:
+
+  ```bash
+  echo "Piper smoke test" | "${PIPER_BIN:-piper}" --model "$PIPER_MODEL_PATH" --output_file /tmp/piper-smoke.wav
+  ls -lh /tmp/piper-smoke.wav
+  ```
+
+Piper synthesis returns WAV audio, while Edge synthesis returns MP3 audio.
+
 ### Proactive alerts (doorbell/calendar/energy)
 
 Administrators can trigger Sonos announcements without waiting for a user voice turn by calling `POST /api/voice/alerts` with bearer auth and a JSON payload containing `message` (or `text`) and optional `title`, `room`, and `source`.


### PR DESCRIPTION
## Summary
- add a step-by-step Piper setup section with official install source and model download reference
- include concrete `.env` examples for executable + model path and clarify `PIPER_BIN` vs `PIPER_EXECUTABLE` naming
- add a quick CLI smoke test and document WAV (Piper) vs MP3 (Edge) output behavior

Fixes #8