### PR TITLE
feat: ship VPS-side Sonos relay service (GH-40)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,27 @@ PIPER_NOISE_SCALE=
 PIPER_NOISE_W=
 PIPER_SENTENCE_SILENCE=
 
+# ---------------------------------------------------------------------------
+# VPS-side Sonos relay server (src/sonos-relay-server.js / npm run sonos:relay)
+# These variables are read by the relay server itself, not the voice server.
+# ---------------------------------------------------------------------------
+# Secret bearer token the voice server presents when calling this relay.
+SONOS_RELAY_BEARER_TOKEN=replace-with-a-long-random-token
+# IP of the Sonos speaker reachable from the VPS (e.g. via Tailscale).
+SONOS_IP=192.168.4.33
+# Sonos UPnP port (almost always 1400).
+SONOS_PORT=1400
+# Base URL of this relay reachable *by the Sonos speaker* — used to build the temp clip URL.
+SONOS_RELAY_VPS_URL=http://10.8.0.1:8788
+# Listening port for the relay server.
+SONOS_RELAY_PORT=8788
+# Milliseconds to keep the temp audio clip before deleting it.
+SONOS_RELAY_CLIP_TTL_MS=30000
+
+# ---------------------------------------------------------------------------
+# Voice server → Sonos relay client settings (read by the voice server).
+# Set these on the voice server side to point at the relay above.
+# ---------------------------------------------------------------------------
 # Optional Sonos local relay settings. Leave all blank if you do not use Sonos.
 SONOS_RELAY_URL=
 # Alias for the primary LAN/Pi relay. If SONOS_RELAY_URL is also set, that value wins.

--- a/deploy/systemd/openclaw-voice-sonos-relay.service
+++ b/deploy/systemd/openclaw-voice-sonos-relay.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=openclaw-voice Sonos Relay Service
+After=network.target
+
+[Service]
+Type=simple
+User=openclaw
+WorkingDirectory=/opt/openclaw-voice
+EnvironmentFile=/opt/openclaw-voice/.env
+ExecStart=/usr/bin/node src/sonos-relay-server.js
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sonos-relay
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/sonos-vps-relay-service.md
+++ b/docs/sonos-vps-relay-service.md
@@ -1,0 +1,91 @@
+# Sonos VPS Relay Service
+
+The VPS-side Sonos relay (`src/sonos-relay-server.js`) is the companion service that
+receives audio from `openclaw-voice` and plays it on a Sonos speaker via the Sonos
+UPnP/AVTransport API.
+
+## How it works
+
+1. The voice server synthesises a TTS audio clip and POSTs it (base64-encoded) to this relay.
+2. The relay writes the clip to a temporary file and serves it over a short-lived HTTP URL.
+3. The relay calls the Sonos UPnP `SetAVTransportURI` + `Play` actions, pointing the speaker
+   at that URL.
+4. After `SONOS_RELAY_CLIP_TTL_MS` milliseconds the file is deleted automatically.
+
+## Prerequisites
+
+- Node.js ≥ 20 on the VPS
+- The VPS must be able to reach the Sonos speaker's IP directly (e.g. via Tailscale subnet routing)
+- The Sonos speaker must be able to reach the VPS on `SONOS_RELAY_PORT` to download the audio clip
+
+## Required environment variables
+
+| Variable | Description |
+|---|---|
+| `SONOS_RELAY_BEARER_TOKEN` | Secret token the voice server uses when calling this relay |
+| `SONOS_IP` | IP address of the Sonos speaker (e.g. `192.168.4.33`) |
+| `SONOS_RELAY_VPS_URL` | Base URL of this relay reachable by the Sonos speaker (e.g. `http://10.8.0.1:8788`) |
+
+## Optional environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `SONOS_RELAY_PORT` | `8788` | Port this relay server listens on |
+| `SONOS_PORT` | `1400` | Sonos UPnP port |
+| `SONOS_RELAY_CLIP_TTL_MS` | `30000` | Milliseconds to keep the audio clip file before deleting it |
+
+## Starting the relay
+
+```bash
+node src/sonos-relay-server.js
+```
+
+Or with the npm script:
+
+```bash
+npm run sonos:relay
+```
+
+## systemd setup
+
+Copy the unit file and enable it:
+
+```bash
+sudo cp deploy/systemd/openclaw-voice-sonos-relay.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now openclaw-voice-sonos-relay
+sudo systemctl status openclaw-voice-sonos-relay
+```
+
+The unit file assumes the app lives at `/opt/openclaw-voice` and runs as the `openclaw` user.
+Adjust `WorkingDirectory`, `User`, and `EnvironmentFile` if your setup differs.
+
+## Pointing the voice server at this relay
+
+In the voice server's `.env`, set:
+
+```env
+SONOS_RELAY_URL=http://<vps-ip-or-hostname>:8788/play-audio
+SONOS_RELAY_AUTH_BEARER=<same-value-as-SONOS_RELAY_BEARER_TOKEN>
+SONOS_ROOM_DEFAULT=<your Sonos room name, e.g. Kitchen>
+```
+
+The `SONOS_RELAY_URL` must point to the `/play-audio` endpoint of this relay, at the
+address/port that the voice server can reach it on (which may differ from
+`SONOS_RELAY_VPS_URL` if you use a reverse proxy or Tailscale).
+
+## Health check
+
+```bash
+curl http://localhost:8788/health
+# {"ok":true,"sonosIp":"192.168.4.33","sonosPort":1400,"vpsBaseUrl":"http://10.8.0.1:8788"}
+```
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| `missing required env vars` on startup | Verify all three required vars are in `.env` |
+| `Sonos SOAP SetAVTransportURI failed (500)` | Confirm `SONOS_IP` and VPS → Sonos network path |
+| Sonos does not play | Verify the Sonos speaker can reach `SONOS_RELAY_VPS_URL` — check `SONOS_RELAY_VPS_URL` is set to the correct VPS address from the Sonos device's perspective |
+| `Clip not found or expired` errors in logs | Increase `SONOS_RELAY_CLIP_TTL_MS` if Sonos is slow to fetch the clip |

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
     "desktop:client": "node desktop/client.js",
+    "sonos:relay": "node src/sonos-relay-server.js",
     "test": "node --test"
   },
   "engines": {

--- a/src/sonos-relay-lib.js
+++ b/src/sonos-relay-lib.js
@@ -1,0 +1,133 @@
+/**
+ * sonos-relay-lib.js
+ *
+ * Shared helpers for the VPS-side Sonos relay service.
+ * All Sonos UPnP/SOAP interaction lives here so unit tests can inject stubs.
+ */
+
+/**
+ * Build a Sonos AVTransport SOAP action envelope.
+ *
+ * @param {string} action  - SOAP action name, e.g. "SetAVTransportURI"
+ * @param {string} bodyXml - Inner XML fragment for the action body
+ * @returns {string} Full SOAP envelope string
+ */
+export function buildSoapEnvelope(action, bodyXml) {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
+            s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <s:Body>
+    <u:${action} xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+      ${bodyXml}
+    </u:${action}>
+  </s:Body>
+</s:Envelope>`;
+}
+
+/**
+ * Send a Sonos AVTransport UPnP/SOAP request.
+ *
+ * @param {object} opts
+ * @param {string} opts.sonosIp    - IP address of the Sonos speaker
+ * @param {number} opts.sonosPort  - UPnP port (default 1400)
+ * @param {string} opts.action     - SOAP action name
+ * @param {string} opts.bodyXml    - Inner XML for the action body
+ * @param {Function} [opts.fetchImpl] - Optional fetch override for testing
+ * @returns {Promise<void>}
+ */
+export async function sendSoapAction({ sonosIp, sonosPort = 1400, action, bodyXml, fetchImpl }) {
+  const fetch_ = fetchImpl || globalThis.fetch;
+  const url = `http://${sonosIp}:${sonosPort}/MediaRenderer/AVTransport/Control`;
+  const envelope = buildSoapEnvelope(action, bodyXml);
+
+  const response = await fetch_(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "text/xml; charset=utf-8",
+      SOAPAction: `"urn:schemas-upnp-org:service:AVTransport:1#${action}"`
+    },
+    body: envelope
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Sonos SOAP ${action} failed (${response.status}): ${text}`);
+  }
+}
+
+/**
+ * Set the Sonos speaker's current transport URI to the given audio URL.
+ *
+ * @param {object} opts
+ * @param {string} opts.sonosIp
+ * @param {number} [opts.sonosPort]
+ * @param {string} opts.audioUrl   - Public HTTP URL the Sonos device can reach
+ * @param {string} opts.audioMimeType
+ * @param {Function} [opts.fetchImpl]
+ */
+export async function setSonosUri({ sonosIp, sonosPort, audioUrl, audioMimeType, fetchImpl }) {
+  const metaXml = buildDidlLite(audioUrl, audioMimeType);
+  const escapedUrl = escapeXml(audioUrl);
+  const escapedMeta = escapeXml(metaXml);
+
+  await sendSoapAction({
+    sonosIp,
+    sonosPort,
+    action: "SetAVTransportURI",
+    bodyXml: `<InstanceID>0</InstanceID>
+               <CurrentURI>${escapedUrl}</CurrentURI>
+               <CurrentURIMetaData>${escapedMeta}</CurrentURIMetaData>`,
+    fetchImpl
+  });
+}
+
+/**
+ * Send the Play action to start playback.
+ *
+ * @param {object} opts
+ * @param {string} opts.sonosIp
+ * @param {number} [opts.sonosPort]
+ * @param {Function} [opts.fetchImpl]
+ */
+export async function playSonos({ sonosIp, sonosPort, fetchImpl }) {
+  await sendSoapAction({
+    sonosIp,
+    sonosPort,
+    action: "Play",
+    bodyXml: `<InstanceID>0</InstanceID><Speed>1</Speed>`,
+    fetchImpl
+  });
+}
+
+/**
+ * Build a minimal DIDL-Lite metadata fragment for the given audio URL.
+ *
+ * @param {string} url
+ * @param {string} mimeType
+ * @returns {string}
+ */
+function buildDidlLite(url, mimeType) {
+  const safe = escapeXml(url);
+  return `<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">` +
+    `<item id="1" parentID="0" restricted="1">` +
+    `<dc:title>openclaw-voice</dc:title>` +
+    `<upnp:class>object.item.audioItem.musicTrack</upnp:class>` +
+    `<res protocolInfo="http-get:*:${escapeXml(mimeType)}:*">${safe}</res>` +
+    `</item>` +
+    `</DIDL-Lite>`;
+}
+
+/**
+ * Escape characters that are invalid inside XML text/attribute content.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+export function escapeXml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}

--- a/src/sonos-relay-server.js
+++ b/src/sonos-relay-server.js
@@ -1,0 +1,187 @@
+/**
+ * sonos-relay-server.js
+ *
+ * VPS-side Sonos relay service for openclaw-voice.
+ *
+ * Accepts POST /play-audio from the voice server, decodes the base64
+ * audio, serves it over a temporary HTTP URL that the Sonos speaker can
+ * reach, and triggers UPnP playback via the Sonos AVTransport API.
+ *
+ * Required env vars:
+ *   SONOS_RELAY_BEARER_TOKEN   - bearer token the voice server must present
+ *   SONOS_IP                   - IP of the target Sonos speaker (e.g. 192.168.4.33)
+ *   SONOS_RELAY_VPS_URL        - public base URL of this service that the Sonos
+ *                                speaker can reach (e.g. http://10.x.x.x:8788)
+ *
+ * Optional env vars:
+ *   SONOS_RELAY_PORT            - listening port (default 8788)
+ *   SONOS_PORT                  - Sonos UPnP port (default 1400)
+ *   SONOS_RELAY_CLIP_TTL_MS     - ms to keep the temp audio file (default 30000)
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+import dotenv from "dotenv";
+import express from "express";
+
+import { setSonosUri, playSonos } from "./sonos-relay-lib.js";
+
+dotenv.config();
+
+const requiredEnv = ["SONOS_RELAY_BEARER_TOKEN", "SONOS_IP", "SONOS_RELAY_VPS_URL"];
+const missingEnv = requiredEnv.filter((key) => !process.env[key]);
+if (missingEnv.length > 0) {
+  throw new Error(`sonos-relay-server: missing required env vars: ${missingEnv.join(", ")}`);
+}
+
+const RELAY_PORT = Number(process.env.SONOS_RELAY_PORT || 8788);
+const SONOS_IP = process.env.SONOS_IP;
+const SONOS_PORT = Number(process.env.SONOS_PORT || 1400);
+const VPS_BASE_URL = process.env.SONOS_RELAY_VPS_URL.replace(/\/$/, "");
+const CLIP_TTL_MS = Number(process.env.SONOS_RELAY_CLIP_TTL_MS || 30000);
+const BEARER_TOKEN = process.env.SONOS_RELAY_BEARER_TOKEN;
+
+// Temp directory for audio clips
+const CLIP_DIR = path.join(os.tmpdir(), "sonos-relay-clips");
+await fs.promises.mkdir(CLIP_DIR, { recursive: true });
+
+const app = express();
+app.disable("x-powered-by");
+app.use(express.json({ limit: "20mb" }));
+
+function requireBearer(req, res, next) {
+  const header = req.headers.authorization || "";
+  if (!header.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Missing bearer token" });
+    return;
+  }
+  if (header.slice("Bearer ".length).trim() !== BEARER_TOKEN) {
+    res.status(401).json({ error: "Invalid bearer token" });
+    return;
+  }
+  next();
+}
+
+/**
+ * Serve a stored audio clip by filename.
+ * No auth required — the URL is a random UUID path, and Sonos devices
+ * cannot present bearer tokens.
+ */
+app.get("/clips/:filename", async (req, res) => {
+  const filename = path.basename(req.params.filename);
+  const filePath = path.join(CLIP_DIR, filename);
+
+  try {
+    const stat = await fs.promises.stat(filePath);
+    const ext = path.extname(filename).replace(".", "").toLowerCase();
+    const mimeByExt = {
+      mp3: "audio/mpeg",
+      wav: "audio/wav",
+      ogg: "audio/ogg",
+      aac: "audio/aac",
+      m4a: "audio/mp4"
+    };
+    const contentType = mimeByExt[ext] || "application/octet-stream";
+    res.set("Content-Type", contentType);
+    res.set("Content-Length", stat.size);
+    fs.createReadStream(filePath).pipe(res);
+  } catch {
+    res.status(404).json({ error: "Clip not found or expired" });
+  }
+});
+
+app.get("/health", (_req, res) => {
+  res.json({
+    ok: true,
+    sonosIp: SONOS_IP,
+    sonosPort: SONOS_PORT,
+    vpsBaseUrl: VPS_BASE_URL
+  });
+});
+
+/**
+ * POST /play-audio
+ *
+ * Body: { room, text, audioBase64, audioMimeType }
+ * Decodes audio, serves it as a temp clip URL, and plays it on Sonos.
+ */
+app.post("/play-audio", requireBearer, async (req, res) => {
+  const { room, text, audioBase64, audioMimeType } = req.body || {};
+
+  if (!audioBase64) {
+    res.status(400).json({ error: "audioBase64 is required" });
+    return;
+  }
+  if (!audioMimeType) {
+    res.status(400).json({ error: "audioMimeType is required" });
+    return;
+  }
+
+  let audioBuffer;
+  try {
+    audioBuffer = Buffer.from(audioBase64, "base64");
+  } catch {
+    res.status(400).json({ error: "audioBase64 is not valid base64" });
+    return;
+  }
+
+  // Derive a file extension from the MIME type
+  const extByMime = {
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/wav": "wav",
+    "audio/wave": "wav",
+    "audio/ogg": "ogg",
+    "audio/aac": "aac",
+    "audio/mp4": "m4a"
+  };
+  const ext = extByMime[audioMimeType.toLowerCase()] || "mp3";
+  const clipId = crypto.randomUUID();
+  const filename = `${clipId}.${ext}`;
+  const filePath = path.join(CLIP_DIR, filename);
+  const clipUrl = `${VPS_BASE_URL}/clips/${filename}`;
+
+  try {
+    await fs.promises.writeFile(filePath, audioBuffer);
+
+    // Schedule cleanup after TTL
+    setTimeout(() => {
+      fs.promises.unlink(filePath).catch(() => {});
+    }, CLIP_TTL_MS);
+
+    await setSonosUri({
+      sonosIp: SONOS_IP,
+      sonosPort: SONOS_PORT,
+      audioUrl: clipUrl,
+      audioMimeType
+    });
+
+    await playSonos({
+      sonosIp: SONOS_IP,
+      sonosPort: SONOS_PORT
+    });
+
+    res.json({
+      ok: true,
+      room: room || null,
+      clipUrl,
+      sonosIp: SONOS_IP
+    });
+  } catch (error) {
+    // Best-effort cleanup on failure
+    fs.promises.unlink(filePath).catch(() => {});
+    res.status(502).json({
+      error: "Sonos relay failed",
+      details: error instanceof Error ? error.message : String(error)
+    });
+  }
+});
+
+app.listen(RELAY_PORT, () => {
+  process.stdout.write(
+    `sonos-relay-server listening on :${RELAY_PORT} (Sonos: ${SONOS_IP}:${SONOS_PORT})\n`
+  );
+});

--- a/test/sonos-relay.test.js
+++ b/test/sonos-relay.test.js
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildSoapEnvelope,
+  escapeXml,
+  setSonosUri,
+  playSonos
+} from "../src/sonos-relay-lib.js";
+
+test("escapeXml handles all special characters", () => {
+  assert.equal(escapeXml('&<>"\''), "&amp;&lt;&gt;&quot;&apos;");
+  assert.equal(escapeXml("hello world"), "hello world");
+  assert.equal(escapeXml("http://host/path?a=1&b=2"), "http://host/path?a=1&amp;b=2");
+});
+
+test("buildSoapEnvelope wraps body in valid SOAP envelope", () => {
+  const xml = buildSoapEnvelope("Play", "<InstanceID>0</InstanceID><Speed>1</Speed>");
+  assert.ok(xml.includes('<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"'));
+  assert.ok(xml.includes('<u:Play xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">'));
+  assert.ok(xml.includes("<InstanceID>0</InstanceID>"));
+  assert.ok(xml.includes("</u:Play>"));
+  assert.ok(xml.includes("</s:Envelope>"));
+});
+
+test("setSonosUri sends SetAVTransportURI SOAP action with correct headers", async () => {
+  const calls = [];
+  const mockFetch = async (url, opts) => {
+    calls.push({ url, opts });
+    return { ok: true, text: async () => "" };
+  };
+
+  await setSonosUri({
+    sonosIp: "192.168.4.33",
+    sonosPort: 1400,
+    audioUrl: "http://10.0.0.1:8788/clips/test.mp3",
+    audioMimeType: "audio/mpeg",
+    fetchImpl: mockFetch
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "http://192.168.4.33:1400/MediaRenderer/AVTransport/Control");
+  assert.equal(calls[0].opts.method, "POST");
+  assert.ok(
+    calls[0].opts.headers.SOAPAction.includes("SetAVTransportURI"),
+    "SOAPAction header should reference SetAVTransportURI"
+  );
+  assert.ok(
+    calls[0].opts.body.includes("SetAVTransportURI"),
+    "body should contain SetAVTransportURI action"
+  );
+  assert.ok(
+    calls[0].opts.body.includes("http://10.0.0.1:8788/clips/test.mp3"),
+    "body should contain the clip URL"
+  );
+});
+
+test("playSonos sends Play SOAP action", async () => {
+  const calls = [];
+  const mockFetch = async (url, opts) => {
+    calls.push({ url, opts });
+    return { ok: true, text: async () => "" };
+  };
+
+  await playSonos({ sonosIp: "192.168.4.33", sonosPort: 1400, fetchImpl: mockFetch });
+
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].opts.headers.SOAPAction.includes("Play"), "SOAPAction should reference Play");
+  assert.ok(calls[0].opts.body.includes("<u:Play"), "body should contain Play action element");
+  assert.ok(calls[0].opts.body.includes("<Speed>1</Speed>"), "body should contain Speed element");
+});
+
+test("setSonosUri rejects when Sonos returns non-2xx status", async () => {
+  const mockFetch = async () => ({
+    ok: false,
+    status: 500,
+    text: async () => "UPnP error"
+  });
+
+  await assert.rejects(
+    () =>
+      setSonosUri({
+        sonosIp: "192.168.4.33",
+        sonosPort: 1400,
+        audioUrl: "http://10.0.0.1:8788/clips/test.mp3",
+        audioMimeType: "audio/mpeg",
+        fetchImpl: mockFetch
+      }),
+    /Sonos SOAP SetAVTransportURI failed \(500\)/
+  );
+});
+
+test("setSonosUri escapes special chars in audio URL", async () => {
+  const calls = [];
+  const mockFetch = async (url, opts) => {
+    calls.push({ url, opts });
+    return { ok: true, text: async () => "" };
+  };
+
+  await setSonosUri({
+    sonosIp: "192.168.4.33",
+    sonosPort: 1400,
+    audioUrl: "http://10.0.0.1:8788/clips/test&clip.mp3",
+    audioMimeType: "audio/mpeg",
+    fetchImpl: mockFetch
+  });
+
+  assert.ok(
+    calls[0].opts.body.includes("&amp;"),
+    "URL ampersand should be XML-escaped in SOAP body"
+  );
+});


### PR DESCRIPTION
## Summary

- Adds `src/sonos-relay-server.js` — standalone Express relay that accepts `POST /play-audio` with base64 audio, serves it as a temp clip URL, and drives Sonos playback via UPnP AVTransport SOAP
- Adds `src/sonos-relay-lib.js` — testable helpers for Sonos SOAP calls and XML escaping
- Adds 6 new unit tests (`test/sonos-relay.test.js`); full suite now passes 15/15
- Adds `deploy/systemd/openclaw-voice-sonos-relay.service` for VPS deployment
- Adds `docs/sonos-vps-relay-service.md` with operator setup guide
- Updates `package.json` with `npm run sonos:relay` script
- Updates `.env.example` with all new env vars documented

Closes #40

## Test plan

- [x] `npm test` — 15/15 pass
- [ ] Deploy relay to VPS with `SONOS_IP`, `SONOS_RELAY_VPS_URL`, `SONOS_RELAY_BEARER_TOKEN` set
- [ ] Point voice server `SONOS_RELAY_URL` at `http://<vps>:8788/play-audio`
- [ ] Trigger a voice turn and confirm audio plays on Sonos speaker
- [ ] Verify `GET /health` returns correct config