### PR TITLE
fix: strip markdown formatting before TTS synthesis (GH-50)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ import multer from "multer";
 import { MsEdgeTTS, OUTPUT_FORMAT } from "msedge-tts";
 
 import { createOpenClawClient, readOpenClawClientConfigFromEnv } from "./openclaw-client.js";
+import { stripMarkdown } from "./strip-markdown.js";
 
 dotenv.config();
 
@@ -298,32 +299,33 @@ async function synthesizeSpeechWithEdge(text) {
 }
 
 async function synthesizeSpeech(text) {
+  const cleanText = stripMarkdown(text);
   const preferred = ttsProvider;
   const fallback = ttsFallbackProvider;
 
   if (preferred === "piper") {
-    return synthesizeSpeechWithPiper(text);
+    return synthesizeSpeechWithPiper(cleanText);
   }
 
   if (preferred === "edge") {
     if (fallback === "piper") {
       try {
-        return await synthesizeSpeechWithEdge(text);
+        return await synthesizeSpeechWithEdge(cleanText);
       } catch (error) {
         process.stderr.write(
           `Edge TTS failed, falling back to Piper: ${error instanceof Error ? error.message : String(error)}\n`
         );
-        return synthesizeSpeechWithPiper(text);
+        return synthesizeSpeechWithPiper(cleanText);
       }
     }
-    return synthesizeSpeechWithEdge(text);
+    return synthesizeSpeechWithEdge(cleanText);
   }
 
   if (preferred === "auto") {
     try {
-      return await synthesizeSpeechWithEdge(text);
+      return await synthesizeSpeechWithEdge(cleanText);
     } catch {
-      return synthesizeSpeechWithPiper(text);
+      return synthesizeSpeechWithPiper(cleanText);
     }
   }
 

--- a/src/strip-markdown.js
+++ b/src/strip-markdown.js
@@ -1,0 +1,64 @@
+/**
+ * Strip common markdown formatting so TTS engines read clean plaintext.
+ *
+ * Handles: headings, bold, italic, strikethrough, inline code, fenced code
+ * blocks, blockquotes, unordered/ordered list markers, links, images,
+ * horizontal rules, and HTML tags.
+ */
+export function stripMarkdown(text) {
+  if (!text) return "";
+
+  let result = text;
+
+  // Remove fenced code blocks (``` ... ```) — keep the inner text
+  result = result.replace(/```[\s\S]*?```/g, (match) => {
+    // Strip the fence markers and optional language tag
+    return match
+      .replace(/^```[^\n]*\n?/, "")
+      .replace(/\n?```$/, "");
+  });
+
+  // Remove inline code backticks
+  result = result.replace(/`([^`]*)`/g, "$1");
+
+  // Remove images ![alt](url) → alt
+  result = result.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+  // Convert links [text](url) → text
+  result = result.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+  // Remove heading markers (## Heading → Heading)
+  result = result.replace(/^#{1,6}\s+/gm, "");
+
+  // Remove bold/italic markers: ***text***, **text**, *text*, ___text___, __text__, _text_
+  // Order matters — longest markers first
+  result = result.replace(/\*{3}(.+?)\*{3}/g, "$1");
+  result = result.replace(/\*{2}(.+?)\*{2}/g, "$1");
+  result = result.replace(/\*(.+?)\*/g, "$1");
+  result = result.replace(/_{3}(.+?)_{3}/g, "$1");
+  result = result.replace(/_{2}(.+?)_{2}/g, "$1");
+  result = result.replace(/(?<=\s|^)_(.+?)_(?=\s|$)/gm, "$1");
+
+  // Remove strikethrough ~~text~~ → text
+  result = result.replace(/~~(.+?)~~/g, "$1");
+
+  // Remove blockquote markers
+  result = result.replace(/^>\s?/gm, "");
+
+  // Remove horizontal rules (---, ***, ___)
+  result = result.replace(/^[-*_]{3,}\s*$/gm, "");
+
+  // Remove unordered list markers (-, *, +) at start of line
+  result = result.replace(/^[\t ]*[-*+]\s+/gm, "");
+
+  // Remove ordered list markers (1., 2., etc.)
+  result = result.replace(/^[\t ]*\d+\.\s+/gm, "");
+
+  // Remove simple HTML tags
+  result = result.replace(/<[^>]+>/g, "");
+
+  // Collapse multiple blank lines into one
+  result = result.replace(/\n{3,}/g, "\n\n");
+
+  return result.trim();
+}

--- a/test/strip-markdown.test.js
+++ b/test/strip-markdown.test.js
@@ -1,0 +1,124 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { stripMarkdown } from "../src/strip-markdown.js";
+
+describe("stripMarkdown", () => {
+  it("returns empty string for falsy input", () => {
+    assert.equal(stripMarkdown(""), "");
+    assert.equal(stripMarkdown(null), "");
+    assert.equal(stripMarkdown(undefined), "");
+  });
+
+  it("passes through plain text unchanged", () => {
+    assert.equal(stripMarkdown("Hello world"), "Hello world");
+  });
+
+  it("strips heading markers", () => {
+    assert.equal(stripMarkdown("## Status Update"), "Status Update");
+    assert.equal(stripMarkdown("# Title"), "Title");
+    assert.equal(stripMarkdown("### Sub heading"), "Sub heading");
+  });
+
+  it("strips bold markers", () => {
+    assert.equal(stripMarkdown("This is **bold** text"), "This is bold text");
+    assert.equal(stripMarkdown("This is __bold__ text"), "This is bold text");
+  });
+
+  it("strips italic markers", () => {
+    assert.equal(stripMarkdown("This is *italic* text"), "This is italic text");
+  });
+
+  it("strips bold-italic markers", () => {
+    assert.equal(stripMarkdown("This is ***important***"), "This is important");
+  });
+
+  it("strips strikethrough markers", () => {
+    assert.equal(stripMarkdown("This is ~~deleted~~ text"), "This is deleted text");
+  });
+
+  it("strips inline code backticks", () => {
+    assert.equal(stripMarkdown("Run `npm install` now"), "Run npm install now");
+  });
+
+  it("strips fenced code blocks", () => {
+    const input = "Before\n```js\nconsole.log('hi');\n```\nAfter";
+    const result = stripMarkdown(input);
+    assert.ok(result.includes("console.log('hi');"));
+    assert.ok(!result.includes("```"));
+  });
+
+  it("strips blockquote markers", () => {
+    assert.equal(stripMarkdown("> This is a quote"), "This is a quote");
+  });
+
+  it("strips unordered list markers", () => {
+    const input = "- Item one\n- Item two\n* Item three";
+    const result = stripMarkdown(input);
+    assert.ok(result.includes("Item one"));
+    assert.ok(!result.includes("- "));
+    assert.ok(!result.includes("* "));
+  });
+
+  it("strips ordered list markers", () => {
+    const input = "1. First\n2. Second\n3. Third";
+    const result = stripMarkdown(input);
+    assert.ok(result.includes("First"));
+    assert.ok(!result.match(/^\d+\./m));
+  });
+
+  it("converts links to text only", () => {
+    assert.equal(
+      stripMarkdown("Visit [Google](https://google.com) today"),
+      "Visit Google today"
+    );
+  });
+
+  it("converts images to alt text", () => {
+    assert.equal(
+      stripMarkdown("![screenshot](image.png)"),
+      "screenshot"
+    );
+  });
+
+  it("strips horizontal rules", () => {
+    const input = "Above\n---\nBelow";
+    const result = stripMarkdown(input);
+    assert.ok(!result.includes("---"));
+    assert.ok(result.includes("Above"));
+    assert.ok(result.includes("Below"));
+  });
+
+  it("strips HTML tags", () => {
+    assert.equal(stripMarkdown("Hello <b>world</b>"), "Hello world");
+  });
+
+  it("handles a complex real-world markdown response", () => {
+    const input = [
+      "## Smart Home Status",
+      "",
+      "Here's what's happening:",
+      "",
+      "- **Living Room** temp is *72°F*",
+      "- **Kitchen** light is `on`",
+      "- The [front door](sensor/door) is ~~locked~~ unlocked",
+      "",
+      "> Note: check the garage",
+      "",
+      "1. Turn off lights",
+      "2. Lock doors"
+    ].join("\n");
+
+    const result = stripMarkdown(input);
+
+    assert.ok(!result.includes("##"));
+    assert.ok(!result.includes("**"));
+    assert.ok(!result.includes("*72"));
+    assert.ok(!result.includes("`on`"));
+    assert.ok(!result.includes("~~"));
+    assert.ok(!result.includes("> "));
+    assert.ok(result.includes("Living Room"));
+    assert.ok(result.includes("72°F"));
+    assert.ok(result.includes("front door"));
+    assert.ok(result.includes("unlocked"));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [GH-50](https://github.com/brokemac79/openclaw-voice/issues/50) — TTS engines were receiving raw markdown (headings, bold/italic, code blocks, links, lists) which caused the spoken output to include unwanted symbols and formatting tokens.

### Changes

- **`src/strip-markdown.js`** — new `stripMarkdown()` utility that removes:
  - Headings (`# Heading`)
  - Bold/italic markers (`**text**`, `*text*`, `__text__`, `_text_`)
  - Code blocks (fenced ` ``` ` and inline backticks)
  - Links (`[text](url)` → `text`)
  - List markers (`- `, `* `, `1. `)
  - Blockquotes (`> `)
  - HTML tags
- **`src/server.js`** — calls `stripMarkdown()` inside `synthesizeSpeech()` before handing text to any TTS provider (Edge TTS, Piper)
- **`test/strip-markdown.test.js`** — 17 unit tests covering all stripping rules

### Testing

All 17 tests pass. Run with:
```
npm test
```

Closes #50