### PR TITLE
feat: add OPENCLAW_HTTP_SESSION_ID for voice turn visibility (GH-49)

### DIFF
--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -48,7 +48,8 @@ Columns:
 | `OPENCLAW_CLI_FALLBACK_ENABLED` | Enables local CLI fallback only for `/v1/*` 403 scope regressions | `true` | OpenClaw `2026.3.28` `/v1` token-scope regression workaround | Set manually when you hit `missing scope: operator.read/operator.write` on `/v1` |
 | `OPENCLAW_GATEWAY_TOKEN` | Gateway token exported to the local `openclaw` CLI process during fallback turns | `replace-with-openclaw-gateway-token` | CLI fallback on hosts where `openclaw` requires gateway token auth | Your OpenClaw gateway auth settings |
 | `OPENCLAW_CLI_BIN` | OpenClaw CLI executable used for fallback turns | `openclaw` | CLI fallback mode | Your local PATH or absolute binary path |
-| `OPENCLAW_CLI_SESSION_ID` | Default CLI session id when browser request omits `sessionId` | `openclaw-voice` | CLI fallback mode | Choose any stable session label |
+| `OPENCLAW_HTTP_SESSION_ID` | Default session id injected into HTTP-path voice turns so they appear in Mission Control; falls back to `OPENCLAW_CLI_SESSION_ID`, then `openclaw-voice` | `my-voice-session` | HTTP path (any mode) | Choose any stable session label visible in Mission Control |
+| `OPENCLAW_CLI_SESSION_ID` | Default CLI session id when browser request omits `sessionId`; also used as fallback for `OPENCLAW_HTTP_SESSION_ID` | `openclaw-voice` | CLI fallback mode | Choose any stable session label |
 | `OPENCLAW_CLI_AGENT` | Optional explicit OpenClaw agent id for fallback turns | `ops` | Multi-agent OpenClaw setups using fallback | Your OpenClaw agent config |
 | `OPENCLAW_CLI_TIMEOUT_MS` | Timeout for one fallback CLI turn | `120000` | CLI fallback mode | Set based on expected local model latency |
 

--- a/src/openclaw-client.js
+++ b/src/openclaw-client.js
@@ -167,6 +167,7 @@ export function createOpenClawClient(config, deps = {}) {
     openClawCliFallbackEnabled,
     openClawCliBin,
     openClawCliSessionId,
+    openClawHttpSessionId,
     openClawCliAgent,
     openClawCliTimeoutMs
   } = config;
@@ -174,10 +175,11 @@ export function createOpenClawClient(config, deps = {}) {
   const fetchImpl = deps.fetchImpl || fetch;
   const execFileAsync = deps.execFileAsync || promisify(execFile);
 
-  async function queryViaHttp(text, sessionId) {
+  async function queryViaHttp(text, sessionId, { omitDefaultSession = false } = {}) {
+    const resolvedSessionId = omitDefaultSession ? (sessionId || undefined) : (sessionId || openClawHttpSessionId || undefined);
     const payload = {
       [openClawInputField]: text,
-      sessionId: sessionId || undefined
+      sessionId: resolvedSessionId
     };
 
     const headers = {
@@ -258,16 +260,17 @@ export function createOpenClawClient(config, deps = {}) {
   }
 
   return async function queryOpenClaw(text, sessionId) {
+    const effectiveSessionId = sessionId || openClawHttpSessionId || undefined;
     const primaryResponse = await queryViaHttp(text, sessionId);
-    if (String(primaryResponse || "").trim() || !sessionId) {
+    if (String(primaryResponse || "").trim() || !effectiveSessionId) {
       return primaryResponse;
     }
 
     process.stderr.write(
-      `OpenClaw returned empty text for session '${sessionId}'; retrying once without sessionId to avoid stale-session empty payload bug.\n`
+      `OpenClaw returned empty text for session '${effectiveSessionId}'; retrying once without sessionId to avoid stale-session empty payload bug.\n`
     );
 
-    return queryViaHttp(text, undefined);
+    return queryViaHttp(text, undefined, { omitDefaultSession: true });
   };
 }
 
@@ -281,6 +284,7 @@ export function readOpenClawClientConfigFromEnv(env) {
     openClawCliFallbackEnabled: parseBoolean(env.OPENCLAW_CLI_FALLBACK_ENABLED, false),
     openClawCliBin: env.OPENCLAW_CLI_BIN || "openclaw",
     openClawCliSessionId: env.OPENCLAW_CLI_SESSION_ID || "openclaw-voice",
+    openClawHttpSessionId: env.OPENCLAW_HTTP_SESSION_ID || env.OPENCLAW_CLI_SESSION_ID || "openclaw-voice",
     openClawCliAgent: env.OPENCLAW_CLI_AGENT || "",
     openClawCliTimeoutMs: Number(env.OPENCLAW_CLI_TIMEOUT_MS || 120000)
   };

--- a/test/openclaw-client.test.js
+++ b/test/openclaw-client.test.js
@@ -245,3 +245,102 @@ test("queryOpenClaw retries without session id when first response is empty", as
   assert.equal(seenBodies[0].sessionId, "office");
   assert.equal(seenBodies[1].sessionId, undefined);
 });
+
+test("OPENCLAW_HTTP_SESSION_ID is injected into HTTP turns when caller passes no sessionId", async () => {
+  const config = readOpenClawClientConfigFromEnv({
+    OPENCLAW_URL: "http://127.0.0.1:3000/api/chat",
+    OPENCLAW_HTTP_SESSION_ID: "my-voice-session"
+  });
+
+  const seenBodies = [];
+  const client = createOpenClawClient(config, {
+    fetchImpl: async (_url, options) => {
+      seenBodies.push(JSON.parse(options.body));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ response: "ok" }),
+        text: async () => "",
+        headers: { get: () => "application/json" }
+      };
+    }
+  });
+
+  await client("hello");
+  assert.equal(seenBodies[0].sessionId, "my-voice-session");
+});
+
+test("OPENCLAW_HTTP_SESSION_ID falls back to OPENCLAW_CLI_SESSION_ID then openclaw-voice", async () => {
+  const configCliOnly = readOpenClawClientConfigFromEnv({
+    OPENCLAW_URL: "http://127.0.0.1:3000/api/chat",
+    OPENCLAW_CLI_SESSION_ID: "cli-session"
+  });
+  assert.equal(configCliOnly.openClawHttpSessionId, "cli-session");
+
+  const configDefault = readOpenClawClientConfigFromEnv({
+    OPENCLAW_URL: "http://127.0.0.1:3000/api/chat"
+  });
+  assert.equal(configDefault.openClawHttpSessionId, "openclaw-voice");
+});
+
+test("caller-supplied sessionId takes precedence over OPENCLAW_HTTP_SESSION_ID", async () => {
+  const config = readOpenClawClientConfigFromEnv({
+    OPENCLAW_URL: "http://127.0.0.1:3000/api/chat",
+    OPENCLAW_HTTP_SESSION_ID: "default-session"
+  });
+
+  const seenBodies = [];
+  const client = createOpenClawClient(config, {
+    fetchImpl: async (_url, options) => {
+      seenBodies.push(JSON.parse(options.body));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ response: "ok" }),
+        text: async () => "",
+        headers: { get: () => "application/json" }
+      };
+    }
+  });
+
+  await client("hello", "caller-session");
+  assert.equal(seenBodies[0].sessionId, "caller-session");
+});
+
+test("empty-response retry omits session even when OPENCLAW_HTTP_SESSION_ID is set", async () => {
+  const config = readOpenClawClientConfigFromEnv({
+    OPENCLAW_URL: "http://127.0.0.1:3000/api/chat",
+    OPENCLAW_HTTP_SESSION_ID: "voice-session"
+  });
+
+  const seenBodies = [];
+  let callCount = 0;
+  const client = createOpenClawClient(config, {
+    fetchImpl: async (_url, options) => {
+      callCount += 1;
+      seenBodies.push(JSON.parse(options.body));
+      if (callCount === 1) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ payloads: [] }),
+          text: async () => "",
+          headers: { get: () => "application/json" }
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ response: "retry ok" }),
+        text: async () => "",
+        headers: { get: () => "application/json" }
+      };
+    }
+  });
+
+  const result = await client("ping", "office");
+  assert.equal(result, "retry ok");
+  assert.equal(callCount, 2);
+  assert.equal(seenBodies[0].sessionId, "office");
+  assert.equal(seenBodies[1].sessionId, undefined);
+});


### PR DESCRIPTION
## Summary

Fixes [GH-49](https://github.com/brokemac79/openclaw-voice/issues/49) — HTTP-path voice turns had no session ID, so they never appeared in OpenClaw Mission Control.

### Changes

- **`src/openclaw-client.js`**
  - `readOpenClawClientConfigFromEnv` reads `OPENCLAW_HTTP_SESSION_ID` with fallback chain: `OPENCLAW_HTTP_SESSION_ID` → `OPENCLAW_CLI_SESSION_ID` → `"openclaw-voice"`
  - Adds `openClawHttpSessionId` to the config shape
  - `queryViaHttp()` injects the resolved session when caller passes no `sessionId`
  - Caller-supplied `sessionId` still takes precedence
  - Empty-response retry path uses `omitDefaultSession: true` so the stale-session workaround continues to work unchanged
- **`docs/env-reference.md`** — documents new `OPENCLAW_HTTP_SESSION_ID` variable
- **`test/openclaw-client.test.js`** — 4 new tests covering injection, fallback chain, caller precedence, and retry behaviour (19 total, all pass)

### Acceptance

- [x] Voice turns accumulate in a stable named session visible in Mission Control
- [x] `OPENCLAW_HTTP_SESSION_ID` respected when set
- [x] Default fallback: `OPENCLAW_HTTP_SESSION_ID` → `OPENCLAW_CLI_SESSION_ID` → `openclaw-voice`
- [x] CLI path unchanged (still uses `OPENCLAW_CLI_SESSION_ID`)
- [x] Client-supplied `sessionId` still takes precedence

Closes #49