### PR TITLE
fix: default OpenWakeWord inference framework to onnx for Windows Python 3.12 (GH-48)

### DIFF
--- a/desktop/client.js
+++ b/desktop/client.js
@@ -45,6 +45,7 @@ const wakeProvider = (process.env.VOICE_CLIENT_WAKE_PROVIDER || "porcupine").tri
 const owwPythonBin = process.env.VOICE_CLIENT_OWW_PYTHON_BIN || "python3";
 const owwModel = process.env.VOICE_CLIENT_OWW_MODEL || "hey_jarvis";
 const owwThreshold = parseFloatWithDefault(process.env.VOICE_CLIENT_OWW_THRESHOLD, 0.5);
+const owwInferenceFramework = process.env.VOICE_CLIENT_OWW_INFERENCE_FRAMEWORK || "onnx";
 
 const hotkeyKey = (process.env.VOICE_CLIENT_HOTKEY_KEY || "SPACE").trim().toUpperCase();
 const hotkeyModifiers = (process.env.VOICE_CLIENT_HOTKEY_MODIFIERS || "CTRL+SHIFT")
@@ -297,7 +298,8 @@ async function startOpenWakeWordDetector(onWake) {
   const args = [
     scriptPath,
     "--model", owwModel,
-    "--threshold", String(owwThreshold)
+    "--threshold", String(owwThreshold),
+    "--inference-framework", owwInferenceFramework
   ];
 
   const child = spawn(owwPythonBin, args, {

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -171,6 +171,7 @@ Install first: `pip install openwakeword pyaudio numpy`
 | `VOICE_CLIENT_OWW_MODEL` | Wake word model name or path | `hey_jarvis` | OpenWakeWord mode | Pre-trained model names: `hey_jarvis`, `alexa`, `hey_mycroft`, `hey_rhasspy`; or a path to a custom `.tflite` model |
 | `VOICE_CLIENT_OWW_THRESHOLD` | Detection score threshold (0.0–1.0) | `0.5` | OpenWakeWord mode | Lower = more sensitive, higher = fewer false positives |
 | `VOICE_CLIENT_OWW_PYTHON_BIN` | Python executable used to run the OpenWakeWord sidecar | `python3` | OpenWakeWord mode | The Python executable in your venv or system PATH |
+| `VOICE_CLIENT_OWW_INFERENCE_FRAMEWORK` | Inference backend for OpenWakeWord | `onnx` | OpenWakeWord mode | `onnx` (default, works everywhere) or `tflite` (Linux/Mac only with Python <3.12) |
 
 ## Global hotkey (advanced / optional)
 


### PR DESCRIPTION
## Summary

- Fixes startup failure on Windows + Python 3.12 where `tflite-runtime` has no available wheel
- Defaults `--inference-framework` to `onnx` (available on all platforms) instead of `tflite`
- Passes new `VOICE_CLIENT_OWW_INFERENCE_FRAMEWORK` env var through to the OpenWakeWord sidecar so operators can override

## Details

`tflite-runtime` does not publish a wheel for Windows + Python 3.12, causing the OpenWakeWord sidecar to fail at import time on that platform. `onnxruntime` is available everywhere and is now the default.

Closes https://github.com/brokemac79/openclaw-voice/issues/48

## Test plan

- [ ] Run OpenWakeWord on Windows + Python 3.12 — sidecar should start without `tflite-runtime` installed
- [ ] Verify `VOICE_CLIENT_OWW_INFERENCE_FRAMEWORK=tflite` still works on Linux/Mac with Python <3.12
- [ ] Verify `VOICE_CLIENT_OWW_INFERENCE_FRAMEWORK=onnx` works on all platforms
- [ ] Check env-reference.md renders the new table row correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)