### PR TITLE
docs: update README and env-reference for issues #58-68 (MCSAAAA-381)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Pick the smallest setup that matches what you want to do.
 | Setup | Best for | What you need | Start here |
 | --- | --- | --- | --- |
 | Browser-only | Someone who just wants push-to-talk in a web page | Running voice server, browser mic access, token | `docs/user-guide.md` |
-| Browser + local speech | Self-hosters who want speech-to-text on their own machine | Browser-only setup plus Python, `faster-whisper`, `ffmpeg` | `docs/host-it-yourself.md` |
+| Browser + local speech | Self-hosters who want speech-to-text on their own machine | Browser-only setup plus a configured STT provider (`faster-whisper` by default; see `STT_PROVIDER` in `docs/env-reference.md`) | `docs/host-it-yourself.md` |
 | Desktop + wake word | Always-on desk or mini-PC setups | Local server plus desktop client, `sox`, optional Porcupine wake word files | `docs/desktop-client-walkthrough.md` |
 | Sonos playback | Homes/offices that want spoken replies on Sonos | Any setup above plus an external Sonos relay service | `docs/user-guide.md` and `docs/env-reference.md` |
 
@@ -131,15 +131,17 @@ You speak -> speech-to-text -> OpenClaw -> text-to-speech -> audio reply
 
 ## For developers: implementation details
 
-- Local STT via `faster-whisper` (no OpenAI Whisper dependency)
+- Pluggable STT provider system (`STT_PROVIDER`): `faster-whisper` (default, local), `browser` (Web Speech API, no server audio), `openai-whisper`, `google`, `deepgram`, `vosk` (offline), `azure`
 - Sonos output integration through a local HTTP relay endpoint
+- Shared `sonos-relay-lib.js` exports: `trimTrailingSlash`, `mediaExtensionFromMime`, `buildSonosClipUrl` for relay service implementations
 - Desktop client (`npm run desktop:client`) for non-browser usage
 - Wake word activation (`Hey OpenClaw`) via Picovoice Porcupine
 - Global hotkey fallback trigger when wake word is unavailable
 - Wake confirmation beep on trigger
 - Proactive Sonos alert endpoint (`POST /api/voice/alerts`) for doorbell/calendar/energy events
 - Ambient desktop loop mode for always-on background capture
-- Switchable TTS providers (`TTS_PROVIDER=edge|piper|auto`) with Piper fallback support
+- Switchable TTS providers (`TTS_PROVIDER=edge|piper|auto`) with Piper fallback support; markdown stripped before synthesis on all TTS paths
+- Voice-optimised system prompt (`OPENCLAW_VOICE_SYSTEM_PROMPT`) injected on CLI fallback turns to avoid markdown in spoken replies
 - Dual-relay support for Sonos migration (`SONOS_RELAY_URL` / `SONOS_RELAY_PI_URL` + `SONOS_RELAY_FALLBACK_URL`)
 
 ## Prerequisites (single checklist)
@@ -256,6 +258,8 @@ If you only want to talk to OpenClaw in a browser, stop here and use `docs/user-
 6. Open `http://localhost:8787` and use the web client.
 
 ## faster-whisper Python setup (beginner-friendly)
+
+This section applies when `STT_PROVIDER=faster-whisper` (the default). If you are using a different STT provider, skip this section and see `docs/env-reference.md` for that provider's setup.
 
 If you have never installed Python tooling before, follow these steps exactly on the same machine that runs the Node server.
 
@@ -394,7 +398,7 @@ Run this checklist in order so each layer is validated before the next one.
 curl http://localhost:8787/health
 ```
 
-Expected: `{"ok":true}`
+Expected: `{"ok":true,"sttProvider":"faster-whisper","ttsProvider":"edge",...}`
 
 `curl` is a terminal command available by default on macOS, Linux, and Windows 10+. If you prefer, open `http://localhost:8787/health` in your browser instead - you should see `{"ok":true}`.
 
@@ -613,6 +617,7 @@ OpenClaw options:
 - `OPENCLAW_METHOD` (default `POST`)
 - `OPENCLAW_INPUT_FIELD` (default `input`)
 - `OPENCLAW_OUTPUT_FIELD` (default `response`)
+- `OPENCLAW_VOICE_SYSTEM_PROMPT` (CLI fallback mode; default: built-in voice-optimised prompt)
 
 ### OpenClaw upstream endpoint contract
 
@@ -655,7 +660,11 @@ Troubleshooting wrong endpoint errors:
 - `405` usually means the endpoint does not allow the configured method (default is `POST`).
 - HTML responses (for example `<!doctype html>`) usually mean `OPENCLAW_URL` is pointed at a web page instead of the JSON API endpoint.
 
-faster-whisper options:
+STT provider options:
+
+- `STT_PROVIDER` (default `faster-whisper`; also supports `browser`, `openai-whisper`, `google`, `deepgram`, `vosk`, `azure`)
+
+faster-whisper options (when `STT_PROVIDER=faster-whisper`):
 
 - `FASTER_WHISPER_PYTHON_BIN` (default `python3`)
 - `FASTER_WHISPER_MODEL` (default `base.en`)
@@ -663,6 +672,37 @@ faster-whisper options:
 - `FASTER_WHISPER_DEVICE` (default `auto`)
 - `FASTER_WHISPER_COMPUTE_TYPE` (default `int8`)
 - `FASTER_WHISPER_TIMEOUT_MS` (default `120000`)
+
+OpenAI Whisper API options (when `STT_PROVIDER=openai-whisper`):
+
+- `OPENAI_API_KEY` (required)
+- `OPENAI_WHISPER_MODEL` (default `whisper-1`)
+- `OPENAI_WHISPER_LANGUAGE` (default `en`)
+- `OPENAI_WHISPER_BASE_URL` (default `https://api.openai.com`)
+
+Google STT options (when `STT_PROVIDER=google`):
+
+- `GOOGLE_STT_API_KEY` (required)
+- `GOOGLE_STT_LANGUAGE_CODE` (default `en-US`)
+- `GOOGLE_STT_MODEL` (default `default`)
+
+Deepgram options (when `STT_PROVIDER=deepgram`):
+
+- `DEEPGRAM_API_KEY` (required)
+- `DEEPGRAM_MODEL` (default `nova-2`)
+- `DEEPGRAM_LANGUAGE` (default `en`)
+
+Vosk options (when `STT_PROVIDER=vosk`):
+
+- `VOSK_MODEL_PATH` (required; path to downloaded Vosk model directory)
+- `VOSK_PYTHON_BIN` (default `python3`)
+- `VOSK_TIMEOUT_MS` (default `120000`)
+
+Azure Cognitive Services STT options (when `STT_PROVIDER=azure`):
+
+- `AZURE_SPEECH_KEY` (required)
+- `AZURE_SPEECH_REGION` (required)
+- `AZURE_SPEECH_LANGUAGE` (default `en-US`)
 
 Sonos relay options:
 

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -53,17 +53,87 @@ Columns:
 | `OPENCLAW_CLI_SESSION_ID` | Default CLI session id when browser request omits `sessionId`; also used as fallback for `OPENCLAW_HTTP_SESSION_ID` | `openclaw-voice` | CLI fallback mode | Choose any stable session label |
 | `OPENCLAW_CLI_AGENT` | Optional explicit OpenClaw agent id for fallback turns | `ops` | Multi-agent OpenClaw setups using fallback | Your OpenClaw agent config |
 | `OPENCLAW_CLI_TIMEOUT_MS` | Timeout for one fallback CLI turn | `120000` | CLI fallback mode | Set based on expected local model latency |
+| `OPENCLAW_VOICE_SYSTEM_PROMPT` | System prompt injected into CLI fallback turns to encourage spoken, non-markdown responses | `You are a voice assistant. Respond conversationally without markdown formatting. Avoid asterisks, bullet points, numbered lists, headers, and code blocks. Spell out numbers naturally. Keep answers concise and direct.` | CLI fallback mode | Override when you want a different voice persona or response style; leave unset to use the built-in default |
 
-## Speech-to-text (`faster-whisper`)
+## Speech-to-text (STT)
 
 | Variable | What it is | Example value | Needed for | Where to get it |
 | --- | --- | --- | --- | --- |
-| `FASTER_WHISPER_PYTHON_BIN` | Python command used to run the transcription helper | `python3` | Local speech transcription | The Python executable available on your machine |
-| `FASTER_WHISPER_MODEL` | Speech model size and language | `base.en` | Local speech transcription | Choose from faster-whisper model options |
-| `FASTER_WHISPER_LANGUAGE` | Language hint for transcription | `en` | Local speech transcription | Pick the spoken language you expect |
-| `FASTER_WHISPER_DEVICE` | Hardware target for transcription | `auto` | Local speech transcription | Usually `auto` or `cpu` |
-| `FASTER_WHISPER_COMPUTE_TYPE` | Performance and memory setting | `int8` | Local speech transcription | Usually keep the default for CPU use |
-| `FASTER_WHISPER_TIMEOUT_MS` | Max wait time before a transcription is treated as failed | `120000` | Local speech transcription | Pick a timeout that matches your hardware |
+| `STT_PROVIDER` | Which speech-to-text engine to use | `faster-whisper` | All self-hosted setups with server-side transcription | Choose `faster-whisper` (default), `browser`, `openai-whisper`, `google`, `deepgram`, `vosk`, or `azure` |
+
+### faster-whisper (default, local)
+
+The default provider. Runs transcription locally using the `faster-whisper` Python package. No API key required.
+
+| Variable | What it is | Example value | Needed for | Where to get it |
+| --- | --- | --- | --- | --- |
+| `FASTER_WHISPER_PYTHON_BIN` | Python command used to run the transcription helper | `python3` | `STT_PROVIDER=faster-whisper` | The Python executable available on your machine |
+| `FASTER_WHISPER_MODEL` | Speech model size and language | `base.en` | `STT_PROVIDER=faster-whisper` | Choose from faster-whisper model options |
+| `FASTER_WHISPER_LANGUAGE` | Language hint for transcription | `en` | `STT_PROVIDER=faster-whisper` | Pick the spoken language you expect |
+| `FASTER_WHISPER_DEVICE` | Hardware target for transcription | `auto` | `STT_PROVIDER=faster-whisper` | Usually `auto` or `cpu` |
+| `FASTER_WHISPER_COMPUTE_TYPE` | Performance and memory setting | `int8` | `STT_PROVIDER=faster-whisper` | Usually keep the default for CPU use |
+| `FASTER_WHISPER_TIMEOUT_MS` | Max wait time before a transcription is treated as failed | `120000` | `STT_PROVIDER=faster-whisper` | Pick a timeout that matches your hardware |
+
+### browser (advanced / optional)
+
+With `STT_PROVIDER=browser`, speech recognition runs entirely in the browser via the Web Speech API. The server does not receive or process any audio file. Instead, the browser submits the transcribed text in the `transcription` field of the request body. No server-side Python setup is required.
+
+There are no additional environment variables for this provider.
+
+### openai-whisper (advanced / optional)
+
+Skip this section unless you want cloud transcription via the OpenAI Whisper API. Requires an OpenAI API key.
+
+| Variable | What it is | Example value | Needed for | Where to get it |
+| --- | --- | --- | --- | --- |
+| `OPENAI_API_KEY` | Your OpenAI API key | `sk-...` | `STT_PROVIDER=openai-whisper` | [OpenAI dashboard](https://platform.openai.com/account/api-keys) |
+| `OPENAI_WHISPER_MODEL` | Whisper model variant to request | `whisper-1` | `STT_PROVIDER=openai-whisper` | OpenAI API docs; usually keep the default |
+| `OPENAI_WHISPER_LANGUAGE` | Language hint sent to the API | `en` | `STT_PROVIDER=openai-whisper` | Optional; omit for auto-detect |
+| `OPENAI_WHISPER_BASE_URL` | Base URL for the OpenAI-compatible Whisper endpoint | `https://api.openai.com` | `STT_PROVIDER=openai-whisper` | Change only if you are using a self-hosted or compatible endpoint |
+
+### google (advanced / optional)
+
+Skip this section unless you want cloud transcription via the Google Cloud Speech-to-Text API. Requires a Google API key.
+
+| Variable | What it is | Example value | Needed for | Where to get it |
+| --- | --- | --- | --- | --- |
+| `GOOGLE_STT_API_KEY` | Your Google Cloud API key with Speech-to-Text enabled | `AIza...` | `STT_PROVIDER=google` | [Google Cloud console](https://console.cloud.google.com) |
+| `GOOGLE_STT_LANGUAGE_CODE` | BCP-47 language code for transcription | `en-US` | `STT_PROVIDER=google` | Google Speech-to-Text language support docs |
+| `GOOGLE_STT_MODEL` | Google STT model to use | `default` | `STT_PROVIDER=google` | Optional; `default` works for most use cases |
+
+### deepgram (advanced / optional)
+
+Skip this section unless you want cloud transcription via the Deepgram API.
+
+| Variable | What it is | Example value | Needed for | Where to get it |
+| --- | --- | --- | --- | --- |
+| `DEEPGRAM_API_KEY` | Your Deepgram API key | `abc123...` | `STT_PROVIDER=deepgram` | [Deepgram console](https://console.deepgram.com) |
+| `DEEPGRAM_MODEL` | Deepgram transcription model | `nova-2` | `STT_PROVIDER=deepgram` | Deepgram docs; `nova-2` is the recommended default |
+| `DEEPGRAM_LANGUAGE` | Language code for transcription | `en` | `STT_PROVIDER=deepgram` | Deepgram language support docs |
+
+### vosk (advanced / optional)
+
+Skip this section unless you want fully offline transcription using Vosk. Requires a downloaded Vosk model directory and Python packages.
+
+Install first: `pip install vosk soundfile`
+
+Download a model from <https://alphacephei.com/vosk/models> and unzip it to a local directory.
+
+| Variable | What it is | Example value | Needed for | Where to get it |
+| --- | --- | --- | --- | --- |
+| `VOSK_MODEL_PATH` | Absolute path to the unzipped Vosk model directory | `/opt/vosk/vosk-model-en-us-0.22` | `STT_PROVIDER=vosk` | Unzip a model downloaded from the Vosk models page |
+| `VOSK_PYTHON_BIN` | Python executable used to run the Vosk transcription helper | `python3` | `STT_PROVIDER=vosk` | The Python executable in your venv or system PATH |
+| `VOSK_TIMEOUT_MS` | Max wait time for a Vosk transcription | `120000` | `STT_PROVIDER=vosk` | Increase if transcription times out on slow hardware |
+
+### azure (advanced / optional)
+
+Skip this section unless you want cloud transcription via Azure Cognitive Services Speech.
+
+| Variable | What it is | Example value | Needed for | Where to get it |
+| --- | --- | --- | --- | --- |
+| `AZURE_SPEECH_KEY` | Your Azure Cognitive Services subscription key | `abc123...` | `STT_PROVIDER=azure` | [Azure portal](https://portal.azure.com) — Speech resource keys |
+| `AZURE_SPEECH_REGION` | Azure region where your Speech resource is deployed | `eastus` | `STT_PROVIDER=azure` | Azure portal — Speech resource overview |
+| `AZURE_SPEECH_LANGUAGE` | BCP-47 language code for transcription | `en-US` | `STT_PROVIDER=azure` | Azure Speech language support docs |
 
 ## Edge TTS
 


### PR DESCRIPTION
## Summary

Documentation updates for the #58-68 batch of fixes landing in `feat/stt-providers`.

- **#58** — Added `trimTrailingSlash`, `mediaExtensionFromMime`, `buildSonosClipUrl` to implementation details in README
- **#60-66** — Documented new `STT_PROVIDER` variable with all 7 supported providers (`faster-whisper`, `browser`, `openai-whisper`, `google`, `deepgram`, `vosk`, `azure`); added per-provider env var tables to `docs/env-reference.md` and README; updated `/health` endpoint response example to include `sttProvider`; added STT_PROVIDER caveat to faster-whisper Python setup section
- **#67** — Updated implementation details to note markdown stripping now applies to all TTS paths including ElevenLabs
- **#68** — Added `OPENCLAW_VOICE_SYSTEM_PROMPT` to env-reference Core server table and README OpenClaw options; documented default voice-optimised prompt behaviour

## Test plan

- [ ] Review `docs/env-reference.md` STT section — verify all 7 provider tables are accurate
- [ ] Review README env reference section — confirm `STT_PROVIDER` and provider-specific vars are listed
- [ ] Check README implementation details mentions pluggable STT, markdown stripping, and voice system prompt
- [ ] Confirm `/health` response example in README includes `sttProvider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)