### PR TITLE
fix: openclaw CLI fallback compatibility and voice stage diagnostics

### DIFF
--- a/src/openclaw-client.js
+++ b/src/openclaw-client.js
@@ -88,6 +88,29 @@ function createOneShotSessionId(baseSessionId) {
   return `${baseSessionId}-restart-${timestamp}-${random}`;
 }
 
+function buildLocalCliArgs({ sessionIdForTurn, text, openClawCliAgent, openClawVoiceSystemPrompt, includeSystemPrompt }) {
+  const args = ["agent", "--local", "--json", "--session-id", sessionIdForTurn, "--message", text];
+  if (openClawCliAgent) {
+    args.push("--agent", openClawCliAgent);
+  }
+  if (includeSystemPrompt && openClawVoiceSystemPrompt) {
+    args.push("--system-prompt", openClawVoiceSystemPrompt);
+  }
+  return args;
+}
+
+function isSystemPromptUnsupportedError(error) {
+  const message = [error?.message, error?.stderr, error?.stdout]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+  if (!message.includes("--system-prompt")) {
+    return false;
+  }
+
+  return /unknown\s+(option|flag)|unrecognized\s+(option|argument)|unexpected\s+argument|no\s+such\s+option/.test(message);
+}
+
 export function extractOpenClawText(json, outputField) {
   if (json && typeof json[outputField] === "string") {
     return json[outputField];
@@ -242,18 +265,41 @@ export function createOpenClawClient(config, deps = {}) {
       );
     }
 
-    const args = ["agent", "--local", "--json", "--session-id", sessionIdForTurn, "--message", text];
-    if (openClawCliAgent) {
-      args.push("--agent", openClawCliAgent);
-    }
-    if (openClawVoiceSystemPrompt) {
-      args.push("--system-prompt", openClawVoiceSystemPrompt);
-    }
+    const execLocalCli = async (args) =>
+      execFileAsync(openClawCliBin, args, {
+        timeout: openClawCliTimeoutMs,
+        maxBuffer: 4 * 1024 * 1024
+      });
 
-    const { stdout, stderr } = await execFileAsync(openClawCliBin, args, {
-      timeout: openClawCliTimeoutMs,
-      maxBuffer: 4 * 1024 * 1024
+    const args = buildLocalCliArgs({
+      sessionIdForTurn,
+      text,
+      openClawCliAgent,
+      openClawVoiceSystemPrompt,
+      includeSystemPrompt: true
     });
+
+    let stdout;
+    let stderr;
+    try {
+      ({ stdout, stderr } = await execLocalCli(args));
+    } catch (error) {
+      if (openClawVoiceSystemPrompt && isSystemPromptUnsupportedError(error)) {
+        process.stderr.write(
+          "openclaw CLI rejected --system-prompt; retrying fallback command without that flag for compatibility.\n"
+        );
+        const retryArgs = buildLocalCliArgs({
+          sessionIdForTurn,
+          text,
+          openClawCliAgent,
+          openClawVoiceSystemPrompt,
+          includeSystemPrompt: false
+        });
+        ({ stdout, stderr } = await execLocalCli(retryArgs));
+      } else {
+        throw error;
+      }
+    }
 
     if (stderr?.trim()) {
       process.stderr.write(`openclaw CLI stderr: ${stderr}\n`);

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
@@ -13,6 +14,7 @@ import { MsEdgeTTS, OUTPUT_FORMAT } from "msedge-tts";
 import { createOpenClawClient, readOpenClawClientConfigFromEnv } from "./openclaw-client.js";
 import { stripMarkdown } from "./strip-markdown.js";
 import { createTranscriber, readSttConfigFromEnv } from "./stt.js";
+import { createVoicePipelineLogger } from "./voice-pipeline-logger.js";
 
 dotenv.config();
 
@@ -426,48 +428,114 @@ app.post("/api/voice/alerts", requireBearer, async (req, res) => {
 });
 
 app.post("/api/voice/turn", requireBearer, upload.single("audio"), async (req, res) => {
+  const requestId =
+    (typeof req.headers["x-request-id"] === "string" && req.headers["x-request-id"].trim()) || randomUUID();
+  const logger = createVoicePipelineLogger({
+    context: {
+      requestId,
+      route: "/api/voice/turn",
+      sttProvider: sttConfig.sttProvider
+    }
+  });
+  let failedStage = "unknown";
+
   try {
     let transcribedText;
+
+    failedStage = "validate_input";
+    logger.stageStart(failedStage, {
+      mode: sttConfig.sttProvider === "browser" ? "browser_transcription" : "server_transcription"
+    });
 
     if (sttConfig.sttProvider === "browser") {
       transcribedText = (req.body?.transcription || "").trim();
       if (!transcribedText) {
+        const validationError = new Error("Missing transcription field (STT_PROVIDER=browser expects client-side transcription)");
+        logger.stageFailure(failedStage, validationError);
         res.status(400).json({ error: "Missing transcription field (STT_PROVIDER=browser expects client-side transcription)" });
         return;
       }
     } else {
       if (!req.file?.buffer) {
+        const validationError = new Error("Missing audio upload");
+        logger.stageFailure(failedStage, validationError);
         res.status(400).json({ error: "Missing audio upload" });
         return;
       }
 
+      failedStage = "transcribe_audio";
+      logger.stageSuccess("validate_input");
+      logger.stageStart(failedStage, {
+        bytes: req.file.buffer.length,
+        mimeType: req.file.mimetype || "unknown"
+      });
+
       const uploadFilename = req.file.originalname || "recording.bin";
       const uploadMimeType = resolveAudioContentType(req.file.mimetype, uploadFilename);
       transcribedText = await transcribeAudio(req.file.buffer, uploadFilename, uploadMimeType);
+      logger.stageSuccess(failedStage, {
+        transcriptChars: transcribedText.length
+      });
+    }
+
+    if (sttConfig.sttProvider === "browser") {
+      logger.stageSuccess("validate_input", {
+        transcriptChars: transcribedText.length
+      });
     }
 
     if (!transcribedText) {
+      failedStage = "transcribe_audio";
+      const emptyTranscriptError = new Error("Unable to transcribe audio");
+      logger.stageFailure(failedStage, emptyTranscriptError);
       res.status(422).json({ error: "Unable to transcribe audio" });
       return;
     }
 
+    failedStage = "query_openclaw";
+    logger.stageStart(failedStage, {
+      hasSessionId: Boolean(req.body?.sessionId)
+    });
     const openClawResponse = await queryOpenClaw(transcribedText, req.body?.sessionId);
     const spokenResponse = (openClawResponse || "").trim();
+    logger.stageSuccess(failedStage, {
+      responseChars: spokenResponse.length
+    });
 
     if (!spokenResponse) {
+      failedStage = "query_openclaw";
+      const emptyResponseError = new Error("OpenClaw returned an empty response");
+      logger.stageFailure(failedStage, emptyResponseError);
       res.status(422).json({ error: "OpenClaw returned an empty response" });
       return;
     }
 
+    failedStage = "synthesize_tts";
+    logger.stageStart(failedStage);
     const synthesis = await synthesizeSpeech(spokenResponse);
     const audioBase64 = synthesis.audio.toString("base64");
+    logger.stageSuccess(failedStage, {
+      provider: synthesis.provider,
+      audioBytes: synthesis.audio.length
+    });
+
+    failedStage = "route_sonos";
+    logger.stageStart(failedStage, {
+      room: req.body?.sonosRoom || sonosRoomDefault || ""
+    });
     const sonos = await sendAudioToSonosRelay(
       synthesis.audio,
       spokenResponse,
       req.body?.sonosRoom,
       synthesis.audioMimeType
     );
+    logger.stageSuccess(failedStage, {
+      routed: Boolean(sonos?.routed)
+    });
 
+    logger.stageSuccess("respond", {
+      ok: true
+    });
     res.json({
       transcription: transcribedText,
       responseText: spokenResponse,
@@ -477,8 +545,10 @@ app.post("/api/voice/turn", requireBearer, upload.single("audio"), async (req, r
       sonos
     });
   } catch (error) {
+    logger.pipelineFailure(failedStage, error);
     res.status(500).json({
       error: "Voice pipeline failed",
+      stage: failedStage,
       details: error instanceof Error ? error.message : String(error)
     });
   }

--- a/src/voice-pipeline-logger.js
+++ b/src/voice-pipeline-logger.js
@@ -1,0 +1,53 @@
+export function formatPipelineError(error) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message
+    };
+  }
+
+  return {
+    name: "Error",
+    message: String(error)
+  };
+}
+
+export function createVoicePipelineLogger({ writeLine, nowIso, context = {} } = {}) {
+  const writer = writeLine || ((line) => process.stderr.write(line));
+  const now = nowIso || (() => new Date().toISOString());
+
+  function emit(event, payload = {}) {
+    writer(
+      `${JSON.stringify({
+        type: "voice_pipeline",
+        at: now(),
+        ...context,
+        event,
+        ...payload
+      })}\n`
+    );
+  }
+
+  return {
+    stageStart(stage, payload = {}) {
+      emit("stage_start", { stage, ...payload });
+    },
+    stageSuccess(stage, payload = {}) {
+      emit("stage_success", { stage, ...payload });
+    },
+    stageFailure(stage, error, payload = {}) {
+      emit("stage_failure", {
+        stage,
+        ...payload,
+        error: formatPipelineError(error)
+      });
+    },
+    pipelineFailure(failedStage, error, payload = {}) {
+      emit("pipeline_failure", {
+        failedStage,
+        ...payload,
+        error: formatPipelineError(error)
+      });
+    }
+  };
+}

--- a/test/openclaw-client.test.js
+++ b/test/openclaw-client.test.js
@@ -409,6 +409,44 @@ test("queryViaLocalCli omits --system-prompt when openClawVoiceSystemPrompt is e
   );
 });
 
+test("queryViaLocalCli retries without --system-prompt when CLI does not support the flag", async () => {
+  const config = readOpenClawClientConfigFromEnv({
+    OPENCLAW_URL: "http://127.0.0.1:18789/v1/chat/completions",
+    OPENCLAW_CLI_FALLBACK_ENABLED: "true",
+    OPENCLAW_CLI_SESSION_ID: "voice-tests",
+    OPENCLAW_VOICE_SYSTEM_PROMPT: "Respond without markdown."
+  });
+
+  const seenArgs = [];
+  const client = createOpenClawClient(config, {
+    fetchImpl: async () => ({
+      ok: false,
+      status: 403,
+      text: async () => "missing scope: operator.write",
+      headers: { get: () => "application/json" }
+    }),
+    execFileAsync: async (_bin, args) => {
+      seenArgs.push([...args]);
+      if (seenArgs.length === 1) {
+        const error = new Error("Command failed");
+        error.stderr = "error: unknown option '--system-prompt'";
+        throw error;
+      }
+
+      return {
+        stdout: JSON.stringify({ response: "compat ok" }),
+        stderr: ""
+      };
+    }
+  });
+
+  const result = await client("what time is it", "office");
+  assert.equal(result, "compat ok");
+  assert.equal(seenArgs.length, 2);
+  assert.ok(seenArgs[0].includes("--system-prompt"));
+  assert.ok(!seenArgs[1].includes("--system-prompt"));
+});
+
 // ---------------------------------------------------------------------------
 
 test("empty-response retry omits session even when OPENCLAW_HTTP_SESSION_ID is set", async () => {

--- a/test/voice-pipeline-logger.test.js
+++ b/test/voice-pipeline-logger.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createVoicePipelineLogger, formatPipelineError } from "../src/voice-pipeline-logger.js";
+
+test("formatPipelineError serializes Error instances", () => {
+  const serialized = formatPipelineError(new TypeError("bad input"));
+  assert.deepEqual(serialized, {
+    name: "TypeError",
+    message: "bad input"
+  });
+});
+
+test("createVoicePipelineLogger writes structured stage and failure events", () => {
+  const lines = [];
+  const logger = createVoicePipelineLogger({
+    writeLine: (line) => lines.push(line),
+    nowIso: () => "2026-03-31T00:00:00.000Z",
+    context: {
+      requestId: "req-1",
+      route: "/api/voice/turn"
+    }
+  });
+
+  logger.stageStart("query_openclaw", { hasSessionId: true });
+  logger.stageSuccess("query_openclaw", { responseChars: 42 });
+  logger.pipelineFailure("synthesize_tts", new Error("tts down"));
+
+  assert.equal(lines.length, 3);
+
+  const first = JSON.parse(lines[0]);
+  assert.equal(first.type, "voice_pipeline");
+  assert.equal(first.event, "stage_start");
+  assert.equal(first.stage, "query_openclaw");
+  assert.equal(first.requestId, "req-1");
+  assert.equal(first.route, "/api/voice/turn");
+
+  const second = JSON.parse(lines[1]);
+  assert.equal(second.event, "stage_success");
+  assert.equal(second.responseChars, 42);
+
+  const third = JSON.parse(lines[2]);
+  assert.equal(third.event, "pipeline_failure");
+  assert.equal(third.failedStage, "synthesize_tts");
+  assert.equal(third.error.message, "tts down");
+});


### PR DESCRIPTION
## Summary
- retry local CLI fallback without `--system-prompt` when older OpenClaw binaries reject that option, so fallback remains functional across versions
- add structured voice pipeline stage logging (start/success/failure) and include failed stage in `/api/voice/turn` 500 responses for clearer diagnostics
- add tests for both compatibility fallback behavior and structured pipeline logging output

## Verification
- `npm test`

## Tracking
- Subtask: MCSAAAA-401
- GitHub issues: #72, #73