### PR TITLE
docs: cover fallback compatibility retry and voice pipeline diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ If you only want to talk to OpenClaw in a browser, stop here and use `docs/user-
      - If a turn includes `systemctl --user restart openclaw-gateway`, the server runs that turn in an isolated one-shot session id so your primary session id is not terminated.
      - Chained restart commands (for example `systemctl --user restart openclaw-gateway && curl ...`) are rejected with a clear warning because the restart terminates the active session before chained commands can continue.
 
+     Compatibility note for older `openclaw` CLI builds:
+
+     - If the local CLI does not support `--system-prompt`, OpenClaw Voice retries the same fallback turn once without that flag.
+     - You may see this log line during that retry: `openclaw CLI rejected --system-prompt; retrying fallback command without that flag for compatibility.`
+     - This retry is expected behavior and is not a failure by itself.
+
       Need a plain-English walkthrough for finding the real upstream URL and token requirements? Use `docs/host-it-yourself.md#how-do-i-find-my-real-openclaw-url`.
 
 5. Start server:
@@ -776,6 +782,42 @@ Expected relay behavior:
 - return JSON status
 
 ## API contract
+
+## Voice pipeline diagnostics (structured logs)
+
+When a voice turn fails, OpenClaw Voice emits JSON log lines to stderr/journal so you can see exactly which stage failed.
+
+Log shape:
+
+```json
+{
+  "type": "voice_pipeline",
+  "at": "2026-03-31T23:00:00.000Z",
+  "event": "stage_start|stage_success|stage_failure|pipeline_failure",
+  "stage": "...",
+  "failedStage": "...",
+  "error": { "name": "...", "message": "..." }
+}
+```
+
+Typical stage keys in current releases:
+
+- `validate_input`
+- `transcribe_audio`
+- `query_openclaw`
+- `synthesize_tts`
+- `route_sonos`
+- `respond`
+
+Older releases may emit stage labels such as `stt`, `llm`, or `tts`. Use whichever label appears in your logs.
+
+Quick interpretation:
+
+- `validate_input`: missing upload/transcription payload
+- `transcribe_audio`: STT dependency/config issue
+- `query_openclaw`: upstream URL/token/session/fallback issue
+- `synthesize_tts`: TTS provider/model/credential issue
+- `route_sonos`: relay network/auth/room routing issue
 
 ### `POST /api/voice/turn`
 

--- a/docs/desktop-client-walkthrough.md
+++ b/docs/desktop-client-walkthrough.md
@@ -261,6 +261,24 @@ Try:
 
 If startup fails with `Missing VOICE_CLIENT_BEARER_TOKEN`, add `VOICE_CLIENT_BEARER_TOKEN` or reuse `VOICE_API_BEARER_TOKEN` in `.env`.
 
+### Surface/Windows: request sends but fails before reply
+
+Plain-English meaning: your desktop client recorded audio, but the server failed in one of the backend stages.
+
+What to do first:
+
+1. Copy the exact terminal error from the desktop client.
+2. Ask the server host/operator for the matching `voice_pipeline` log line from `openclaw-voice` service logs.
+3. Match the failure stage to the likely fix:
+
+- `validate_input`: malformed request body or missing transcription/audio
+- `transcribe_audio`: speech-to-text dependency issue on server
+- `query_openclaw`: upstream OpenClaw URL/token/session/fallback issue
+- `synthesize_tts`: text-to-speech dependency or credential issue
+- `route_sonos`: Sonos relay reachability/auth/room issue
+
+If the host sees `openclaw CLI rejected --system-prompt; retrying fallback command without that flag for compatibility.`, that message is expected compatibility behavior for older OpenClaw CLI versions.
+
 ## Related docs
 
 - Hosting and server setup: `docs/host-it-yourself.md`

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -53,7 +53,7 @@ Columns:
 | `OPENCLAW_CLI_SESSION_ID` | Default CLI session id when browser request omits `sessionId`; also used as fallback for `OPENCLAW_HTTP_SESSION_ID` | `openclaw-voice` | CLI fallback mode | Choose any stable session label |
 | `OPENCLAW_CLI_AGENT` | Optional explicit OpenClaw agent id for fallback turns | `ops` | Multi-agent OpenClaw setups using fallback | Your OpenClaw agent config |
 | `OPENCLAW_CLI_TIMEOUT_MS` | Timeout for one fallback CLI turn | `120000` | CLI fallback mode | Set based on expected local model latency |
-| `OPENCLAW_VOICE_SYSTEM_PROMPT` | System prompt injected into CLI fallback turns to encourage spoken, non-markdown responses | `You are a voice assistant. Respond conversationally without markdown formatting. Avoid asterisks, bullet points, numbered lists, headers, and code blocks. Spell out numbers naturally. Keep answers concise and direct.` | CLI fallback mode | Override when you want a different voice persona or response style; leave unset to use the built-in default |
+| `OPENCLAW_VOICE_SYSTEM_PROMPT` | System prompt injected into CLI fallback turns to encourage spoken, non-markdown responses. If the local CLI does not support `--system-prompt`, OpenClaw Voice retries once without that flag for compatibility. | `You are a voice assistant. Respond conversationally without markdown formatting. Avoid asterisks, bullet points, numbered lists, headers, and code blocks. Spell out numbers naturally. Keep answers concise and direct.` | CLI fallback mode | Override when you want a different voice persona or response style; leave unset to use the built-in default |
 
 ## Speech-to-text (STT)
 

--- a/docs/vps-deployment-guide.md
+++ b/docs/vps-deployment-guide.md
@@ -282,6 +282,31 @@ From another device/browser:
 - Confirm enabled state: `sudo systemctl is-enabled openclaw-voice`
 - Re-enable if needed: `sudo systemctl enable openclaw-voice`
 
+### Voice turn fails and you need exact failure stage
+
+1. Pull recent structured pipeline logs:
+
+```bash
+sudo journalctl -u openclaw-voice -n 300 --no-pager | grep '"type":"voice_pipeline"'
+```
+
+2. Look for the most recent `"event":"pipeline_failure"` line and read:
+
+- `failedStage`
+- `error.message`
+
+3. Use this stage map:
+
+- `validate_input`: request payload issue (missing browser transcription or missing uploaded audio)
+- `transcribe_audio`: STT chain issue (`faster-whisper`, Python path, ffmpeg, model)
+- `query_openclaw`: upstream OpenClaw URL/auth/session or fallback CLI issue
+- `synthesize_tts`: TTS provider credentials/dependencies/config
+- `route_sonos`: relay reachability/auth/room mapping
+
+4. If your logs show `openclaw CLI rejected --system-prompt; retrying fallback command without that flag for compatibility.`, treat it as a compatibility warning, not a hard failure. If the turn still fails after that retry, verify `OPENCLAW_CLI_BIN`, `OPENCLAW_AUTH_BEARER`, and `OPENCLAW_GATEWAY_TOKEN` in `/opt/openclaw-voice/.env`.
+
+Note: older builds may emit stage names such as `stt`, `llm`, or `tts` instead of the current names above.
+
 ### Sonos relay check fails or Sonos playback is silent
 
 - Confirm relay env vars are present in `/opt/openclaw-voice/.env` (`SONOS_RELAY_URL`, optional auth/fallback values)


### PR DESCRIPTION
## Summary
- document CLI fallback compatibility behavior when `--system-prompt` is unsupported, including expected retry log messaging
- add structured `voice_pipeline` diagnostics guidance and stage-to-fix mapping in README and VPS deployment troubleshooting
- add Surface/Windows desktop troubleshooting guidance for backend failure stages and update env reference for fallback retry behavior

## Why
Operators needed clear, non-ambiguous docs to troubleshoot #72/#73 behavior changes and quickly identify failing pipeline stages during VPS and Surface deployments.
