### PR TITLE
fix: broaden CLI fallback detection for unsupported system prompt

### DIFF
--- a/src/openclaw-client.js
+++ b/src/openclaw-client.js
@@ -104,11 +104,11 @@ function isSystemPromptUnsupportedError(error) {
     .filter(Boolean)
     .join("\n")
     .toLowerCase();
-  if (!message.includes("--system-prompt")) {
+  if (!/(?:--?system-prompt|system\s+prompt)/.test(message)) {
     return false;
   }
 
-  return /unknown\s+(option|flag)|unrecognized\s+(option|argument)|unexpected\s+argument|no\s+such\s+option/.test(message);
+  return /unknown\s+(option|flag|argument)|unrecognized\s+(option|argument)|unexpected\s+argument|no\s+such\s+option|unsupported\s+(option|flag|argument)|invalid\s+(option|flag|argument)|does\s+not\s+support/.test(message);
 }
 
 export function extractOpenClawText(json, outputField) {

--- a/test/openclaw-client.test.js
+++ b/test/openclaw-client.test.js
@@ -447,6 +447,43 @@ test("queryViaLocalCli retries without --system-prompt when CLI does not support
   assert.ok(!seenArgs[1].includes("--system-prompt"));
 });
 
+test("queryViaLocalCli retries when CLI reports unsupported system prompt without dashed flag text", async () => {
+  const config = readOpenClawClientConfigFromEnv({
+    OPENCLAW_URL: "http://127.0.0.1:18789/v1/chat/completions",
+    OPENCLAW_CLI_FALLBACK_ENABLED: "true",
+    OPENCLAW_CLI_SESSION_ID: "voice-tests",
+    OPENCLAW_VOICE_SYSTEM_PROMPT: "Respond without markdown."
+  });
+
+  const seenArgs = [];
+  const client = createOpenClawClient(config, {
+    fetchImpl: async () => ({
+      ok: false,
+      status: 403,
+      text: async () => "missing scope: operator.write",
+      headers: { get: () => "application/json" }
+    }),
+    execFileAsync: async (_bin, args) => {
+      seenArgs.push([...args]);
+      if (seenArgs.length === 1) {
+        const error = new Error("unsupported argument: system prompt");
+        throw error;
+      }
+
+      return {
+        stdout: JSON.stringify({ response: "compat ok" }),
+        stderr: ""
+      };
+    }
+  });
+
+  const result = await client("what time is it", "office");
+  assert.equal(result, "compat ok");
+  assert.equal(seenArgs.length, 2);
+  assert.ok(seenArgs[0].includes("--system-prompt"));
+  assert.ok(!seenArgs[1].includes("--system-prompt"));
+});
+
 // ---------------------------------------------------------------------------
 
 test("empty-response retry omits session even when OPENCLAW_HTTP_SESSION_ID is set", async () => {


### PR DESCRIPTION
## Summary
- broaden unsupported system-prompt error detection to cover additional CLI phrasing variants seen in runtime environments
- keep the compatibility retry behavior (rerun fallback without --system-prompt) while preserving normal failures for unrelated errors
- add regression test coverage for unsupported error messages that reference system prompt without dashed flag text

## Validation
- npm test