### PR TITLE
fix: add /v1 chat-completions compatibility for OpenClaw Voice

### DIFF
--- a/src/openclaw-client.js
+++ b/src/openclaw-client.js
@@ -99,16 +99,24 @@ function buildLocalCliArgs({ sessionIdForTurn, text, openClawCliAgent, openClawV
   return args;
 }
 
-function isSystemPromptUnsupportedError(error) {
-  const message = [error?.message, error?.stderr, error?.stdout]
-    .filter(Boolean)
-    .join("\n")
-    .toLowerCase();
-  if (!/(?:--?system-prompt|system\s+prompt)/.test(message)) {
+function isSystemPromptUnsupportedText(message) {
+  const normalized = String(message || "").toLowerCase();
+  if (!/(?:--?system-prompt|system\s+prompt)/.test(normalized)) {
     return false;
   }
 
-  return /unknown\s+(option|flag|argument)|unrecognized\s+(option|argument)|unexpected\s+argument|no\s+such\s+option|unsupported\s+(option|flag|argument)|invalid\s+(option|flag|argument)|does\s+not\s+support/.test(message);
+  return /unknown\s+(option|flag|argument)|unrecognized\s+(option|argument)|unexpected\s+argument|no\s+such\s+option|unsupported\s+(option|flag|argument)|invalid\s+(option|flag|argument)|does\s+not\s+support/.test(normalized);
+}
+
+function isSystemPromptUnsupportedError(error) {
+  const message = [error?.message, error?.stderr, error?.stdout]
+    .filter(Boolean)
+    .join("\n");
+  return isSystemPromptUnsupportedText(message);
+}
+
+function isSystemPromptUnsupportedOutput(stdout, stderr) {
+  return isSystemPromptUnsupportedText([stdout, stderr].filter(Boolean).join("\n"));
 }
 
 export function extractOpenClawText(json, outputField) {
@@ -281,8 +289,23 @@ export function createOpenClawClient(config, deps = {}) {
 
     let stdout;
     let stderr;
+    let ranCompatibilityRetry = false;
     try {
       ({ stdout, stderr } = await execLocalCli(args));
+      if (openClawVoiceSystemPrompt && isSystemPromptUnsupportedOutput(stdout, stderr)) {
+        process.stderr.write(
+          "openclaw CLI reported unsupported system-prompt in output; retrying fallback command without that flag for compatibility.\n"
+        );
+        const retryArgs = buildLocalCliArgs({
+          sessionIdForTurn,
+          text,
+          openClawCliAgent,
+          openClawVoiceSystemPrompt,
+          includeSystemPrompt: false
+        });
+        ({ stdout, stderr } = await execLocalCli(retryArgs));
+        ranCompatibilityRetry = true;
+      }
     } catch (error) {
       if (openClawVoiceSystemPrompt && isSystemPromptUnsupportedError(error)) {
         process.stderr.write(
@@ -296,9 +319,16 @@ export function createOpenClawClient(config, deps = {}) {
           includeSystemPrompt: false
         });
         ({ stdout, stderr } = await execLocalCli(retryArgs));
+        ranCompatibilityRetry = true;
       } else {
         throw error;
       }
+    }
+
+    if (!ranCompatibilityRetry && openClawVoiceSystemPrompt && isSystemPromptUnsupportedOutput(stdout, stderr)) {
+      throw new Error(
+        "OpenClaw CLI output still indicates unsupported --system-prompt after fallback command execution."
+      );
     }
 
     if (stderr?.trim()) {

--- a/src/openclaw-client.js
+++ b/src/openclaw-client.js
@@ -30,6 +30,19 @@ function isV1HttpEndpoint(url) {
   }
 }
 
+function isChatCompletionsEndpoint(url) {
+  if (typeof url !== "string" || url.trim().length === 0) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return parsed.pathname === "/v1/chat/completions";
+  } catch {
+    return false;
+  }
+}
+
 function parsePossibleJson(output) {
   const trimmed = String(output || "").trim();
   if (!trimmed) {
@@ -127,6 +140,35 @@ function isSystemPromptUnsupportedOutput(stdout, stderr) {
 }
 
 export function extractOpenClawText(json, outputField) {
+  const extractTextFromContent = (content) => {
+    if (typeof content === "string") {
+      return content;
+    }
+
+    if (Array.isArray(content)) {
+      return content
+        .map((part) => {
+          if (typeof part === "string") {
+            return part;
+          }
+
+          if (typeof part?.text === "string") {
+            return part.text;
+          }
+
+          if (typeof part?.content === "string") {
+            return part.content;
+          }
+
+          return "";
+        })
+        .join(" ")
+        .trim();
+    }
+
+    return "";
+  };
+
   if (json && typeof json[outputField] === "string") {
     return json[outputField];
   }
@@ -147,23 +189,7 @@ export function extractOpenClawText(json, outputField) {
         }
 
         if (Array.isArray(payload?.content)) {
-          return payload.content
-            .map((part) => {
-              if (typeof part === "string") {
-                return part;
-              }
-
-              if (typeof part?.text === "string") {
-                return part.text;
-              }
-
-              if (typeof part?.content === "string") {
-                return part.content;
-              }
-
-              return "";
-            })
-            .join(" ");
+          return extractTextFromContent(payload.content);
         }
 
         return "";
@@ -171,6 +197,29 @@ export function extractOpenClawText(json, outputField) {
       .find((text) => text.trim().length > 0);
     if (payloadText) {
       return payloadText;
+    }
+
+    return "";
+  }
+
+  if (Array.isArray(json?.choices)) {
+    const choiceText = json.choices
+      .map((choice) => {
+        if (typeof choice?.text === "string") {
+          return choice.text;
+        }
+
+        const messageText = extractTextFromContent(choice?.message?.content);
+        if (messageText) {
+          return messageText;
+        }
+
+        return "";
+      })
+      .find((text) => text.trim().length > 0);
+
+    if (choiceText) {
+      return choiceText;
     }
 
     return "";
@@ -216,10 +265,15 @@ export function createOpenClawClient(config, deps = {}) {
 
   async function queryViaHttp(text, sessionId, { omitDefaultSession = false } = {}) {
     const resolvedSessionId = omitDefaultSession ? (sessionId || undefined) : (sessionId || openClawHttpSessionId || undefined);
-    const payload = {
-      [openClawInputField]: text,
-      sessionId: resolvedSessionId
-    };
+    const payload = isChatCompletionsEndpoint(openClawUrl)
+      ? {
+          messages: [{ role: "user", content: text }],
+          sessionId: resolvedSessionId
+        }
+      : {
+          [openClawInputField]: text,
+          sessionId: resolvedSessionId
+        };
 
     const headers = {
       "Content-Type": "application/json"

--- a/src/openclaw-client.js
+++ b/src/openclaw-client.js
@@ -99,13 +99,20 @@ function buildLocalCliArgs({ sessionIdForTurn, text, openClawCliAgent, openClawV
   return args;
 }
 
+function normalizeCliMessage(message) {
+  return String(message || "")
+    .toLowerCase()
+    .replace(/\u001b\[[0-9;]*m/g, "")
+    .replace(/[\u2010\u2011\u2012\u2013\u2014\u2212]/g, "-");
+}
+
 function isSystemPromptUnsupportedText(message) {
-  const normalized = String(message || "").toLowerCase();
+  const normalized = normalizeCliMessage(message);
   if (!/(?:--?system-prompt|system\s+prompt)/.test(normalized)) {
     return false;
   }
 
-  return /unknown\s+(option|flag|argument)|unrecognized\s+(option|argument)|unexpected\s+argument|no\s+such\s+option|unsupported\s+(option|flag|argument)|invalid\s+(option|flag|argument)|does\s+not\s+support/.test(normalized);
+  return /unknown\s+(option|flag|argument)|unrecognized\s+(option|argument)|unexpected\s+argument|found\s+argument|wasn['’]?t\s+expected|isn['’]?t\s+valid|no\s+such\s+option|unsupported\s+(option|flag|argument)|invalid\s+(option|flag|argument)|does\s+not\s+support/.test(normalized);
 }
 
 function isSystemPromptUnsupportedError(error) {

--- a/test/openclaw-client.test.js
+++ b/test/openclaw-client.test.js
@@ -484,6 +484,45 @@ test("queryViaLocalCli retries when CLI reports unsupported system prompt withou
   assert.ok(!seenArgs[1].includes("--system-prompt"));
 });
 
+test("queryViaLocalCli retries when CLI reports unsupported system prompt in stderr with zero exit", async () => {
+  const config = readOpenClawClientConfigFromEnv({
+    OPENCLAW_URL: "http://127.0.0.1:18789/v1/chat/completions",
+    OPENCLAW_CLI_FALLBACK_ENABLED: "true",
+    OPENCLAW_CLI_SESSION_ID: "voice-tests",
+    OPENCLAW_VOICE_SYSTEM_PROMPT: "Respond without markdown."
+  });
+
+  const seenArgs = [];
+  const client = createOpenClawClient(config, {
+    fetchImpl: async () => ({
+      ok: false,
+      status: 403,
+      text: async () => "missing scope: operator.write",
+      headers: { get: () => "application/json" }
+    }),
+    execFileAsync: async (_bin, args) => {
+      seenArgs.push([...args]);
+      if (seenArgs.length === 1) {
+        return {
+          stdout: "",
+          stderr: "error: unknown option --system-prompt"
+        };
+      }
+
+      return {
+        stdout: JSON.stringify({ response: "compat ok" }),
+        stderr: ""
+      };
+    }
+  });
+
+  const result = await client("what time is it", "office");
+  assert.equal(result, "compat ok");
+  assert.equal(seenArgs.length, 2);
+  assert.ok(seenArgs[0].includes("--system-prompt"));
+  assert.ok(!seenArgs[1].includes("--system-prompt"));
+});
+
 // ---------------------------------------------------------------------------
 
 test("empty-response retry omits session even when OPENCLAW_HTTP_SESSION_ID is set", async () => {

--- a/test/openclaw-client.test.js
+++ b/test/openclaw-client.test.js
@@ -523,6 +523,43 @@ test("queryViaLocalCli retries when CLI reports unsupported system prompt in std
   assert.ok(!seenArgs[1].includes("--system-prompt"));
 });
 
+test("queryViaLocalCli retries when CLI uses clap-style wasn't expected phrasing", async () => {
+  const config = readOpenClawClientConfigFromEnv({
+    OPENCLAW_URL: "http://127.0.0.1:18789/v1/chat/completions",
+    OPENCLAW_CLI_FALLBACK_ENABLED: "true",
+    OPENCLAW_CLI_SESSION_ID: "voice-tests",
+    OPENCLAW_VOICE_SYSTEM_PROMPT: "Respond without markdown."
+  });
+
+  const seenArgs = [];
+  const client = createOpenClawClient(config, {
+    fetchImpl: async () => ({
+      ok: false,
+      status: 403,
+      text: async () => "missing scope: operator.write",
+      headers: { get: () => "application/json" }
+    }),
+    execFileAsync: async (_bin, args) => {
+      seenArgs.push([...args]);
+      if (seenArgs.length === 1) {
+        const error = new Error("Found argument '--system-prompt' which wasn't expected, or isn't valid in this context");
+        throw error;
+      }
+
+      return {
+        stdout: JSON.stringify({ response: "compat ok" }),
+        stderr: ""
+      };
+    }
+  });
+
+  const result = await client("what time is it", "office");
+  assert.equal(result, "compat ok");
+  assert.equal(seenArgs.length, 2);
+  assert.ok(seenArgs[0].includes("--system-prompt"));
+  assert.ok(!seenArgs[1].includes("--system-prompt"));
+});
+
 // ---------------------------------------------------------------------------
 
 test("empty-response retry omits session even when OPENCLAW_HTTP_SESSION_ID is set", async () => {

--- a/test/openclaw-client.test.js
+++ b/test/openclaw-client.test.js
@@ -42,6 +42,24 @@ test("extractOpenClawText supports /v1-like payloads", () => {
   );
 });
 
+test("extractOpenClawText supports OpenAI chat-completions response shape", () => {
+  assert.equal(
+    extractOpenClawText(
+      {
+        choices: [
+          {
+            message: {
+              content: "hello from choices"
+            }
+          }
+        ]
+      },
+      "response"
+    ),
+    "hello from choices"
+  );
+});
+
 test("extractOpenClawText supports payload content arrays and empty payload envelopes", () => {
   assert.equal(
     extractOpenClawText(
@@ -99,6 +117,38 @@ test("queryOpenClaw falls back to local CLI on /v1 403 scope failure", async () 
 
   const result = await client("ping", "office");
   assert.equal(result, "fallback ok");
+});
+
+test("queryOpenClaw uses OpenAI chat-completions request shape for /v1/chat/completions", async () => {
+  const config = readOpenClawClientConfigFromEnv({
+    OPENCLAW_URL: "http://127.0.0.1:18789/v1/chat/completions",
+    OPENCLAW_METHOD: "POST",
+    OPENCLAW_INPUT_FIELD: "input",
+    OPENCLAW_OUTPUT_FIELD: "response"
+  });
+
+  const seenBodies = [];
+  const client = createOpenClawClient(config, {
+    fetchImpl: async (_url, options) => {
+      seenBodies.push(JSON.parse(options.body));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          choices: [{ message: { content: "chat ok" } }]
+        }),
+        text: async () => "",
+        headers: { get: () => "application/json" }
+      };
+    }
+  });
+
+  const result = await client("ping", "office");
+  assert.equal(result, "chat ok");
+  assert.deepEqual(seenBodies[0], {
+    messages: [{ role: "user", content: "ping" }],
+    sessionId: "office"
+  });
 });
 
 test("queryOpenClaw parses fallback JSON from stderr when stdout is empty", async () => {


### PR DESCRIPTION
## Summary
- keep non-`/v1` deployments unchanged by continuing to send the configured legacy input field payload
- for `/v1/chat/completions`, send OpenAI-compatible `messages` payloads (`role=user`) so OpenClaw no longer rejects voice turns with contract mismatches
- parse OpenAI-style `choices[].message.content` responses (including structured content arrays) so spoken replies are extracted reliably
- add regression tests for both new request shape and response parsing behavior

## Before / After
- **Before:** `/v1/chat/completions` requests were sent as `{ input, sessionId }` and responses shaped like `choices[].message.content` were not parsed into voice text.
- **After:** `/v1/chat/completions` requests are sent as `{ messages, sessionId }` and `choices` responses are parsed correctly, while legacy non-`/v1` input/output field behavior remains intact.

Fixes #79