### PR TITLE
Harden desktop startup and Sonos relay fallback paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,13 +77,13 @@ EDGE_TTS_PITCH=+0Hz
 # elevenlabs: use ElevenLabs cloud TTS (requires API key)
 # auto: try Edge first then Piper
 TTS_PROVIDER=edge
-# Piper fallback currently applies when TTS_PROVIDER=edge.
+# Fallback applies when TTS_PROVIDER=edge or TTS_PROVIDER=elevenlabs.
 TTS_FALLBACK_PROVIDER=piper
 
 # ElevenLabs TTS configuration (required when TTS_PROVIDER=elevenlabs).
 ELEVENLABS_API_KEY=
 ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
-ELEVENLABS_MODEL=eleven_monolingual_v1
+ELEVENLABS_MODEL=eleven_multilingual_v2
 
 # Local Piper TTS configuration.
 # Required when Piper is used directly or as a fallback.
@@ -124,7 +124,7 @@ SONOS_RELAY_PI_URL=
 SONOS_RELAY_FALLBACK_URL=
 SONOS_RELAY_AUTH_BEARER=
 # Timeout per relay attempt before trying the fallback URL.
-SONOS_RELAY_TIMEOUT_MS=12000
+SONOS_RELAY_TIMEOUT_MS=30000
 SONOS_ROOM_DEFAULT=Kitchen
 
 # Optional desktop client defaults.

--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,10 @@ SONOS_RELAY_VPS_URL=http://10.8.0.1:8788
 SONOS_RELAY_PORT=8788
 # Milliseconds to keep the temp audio clip before deleting it.
 SONOS_RELAY_CLIP_TTL_MS=30000
+# Milliseconds between Sonos playback-state polls before restore.
+SONOS_RELAY_RESTORE_POLL_INTERVAL_MS=500
+# Max wait window before restoring prior source/volume anyway.
+SONOS_RELAY_RESTORE_TIMEOUT_MS=20000
 
 # ---------------------------------------------------------------------------
 # Voice server → Sonos relay client settings (read by the voice server).

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Important: Sonos playback is optional and needs a separate relay service running
 1. Keep `SONOS_RELAY_URL` pointed at the current primary relay, or set `SONOS_RELAY_PI_URL` if you want a clearer LAN/Pi-specific alias.
 2. Set `SONOS_RELAY_FALLBACK_URL` to the secondary relay that should receive traffic if the primary fails.
 3. Set `SONOS_RELAY_AUTH_BEARER` if your relay requires bearer auth.
-4. Adjust `SONOS_RELAY_TIMEOUT_MS` to control how long each relay attempt can take before failover.
+4. Adjust `SONOS_RELAY_TIMEOUT_MS` to control how long each relay attempt can take before failover (default `30000`).
 5. Verify both endpoints with `GET /api/sonos/relay/health` before moving production traffic.
 
 Relay implementation guidance:
@@ -723,8 +723,8 @@ Use these only when you run an external Sonos relay service:
 
 TTS provider options:
 
-- `TTS_PROVIDER` (`edge`, `piper`, `auto`)
-- `TTS_FALLBACK_PROVIDER` (`piper` supported fallback for `edge`)
+- `TTS_PROVIDER` (`edge`, `piper`, `elevenlabs`, `auto`)
+- `TTS_FALLBACK_PROVIDER` (`edge` or `piper` fallback for `edge`/`elevenlabs`)
 - `PIPER_BIN` (default `piper`)
 - `PIPER_MODEL_PATH` (required when using Piper)
 - `PIPER_SPEAKER_ID`
@@ -779,6 +779,7 @@ Expected relay behavior:
 
 - accept local LAN POST requests
 - play supplied MP3 audio on the specified Sonos room
+- when a room is currently playing TV/line-in/other media, snapshot prior state and restore it after the spoken clip
 - return JSON status
 
 ## API contract

--- a/desktop/client.js
+++ b/desktop/client.js
@@ -472,13 +472,22 @@ async function runVoiceTurn(triggerSource) {
   }
 }
 
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
-});
-
 process.stdout.write("OpenClaw desktop voice client started.\n");
-process.stdout.write("Press Enter for manual fallback recording, or type q then Enter to quit.\n");
+
+const hasInteractiveStdin = Boolean(process.stdin?.isTTY);
+const interactiveEnabled = hasInteractiveStdin && wakeMode !== "ambient";
+const rl = interactiveEnabled
+  ? readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    })
+  : null;
+
+if (rl) {
+  process.stdout.write("Press Enter for manual fallback recording, or type q then Enter to quit.\n");
+} else {
+  process.stdout.write("No interactive stdin detected; running in background trigger mode only.\n");
+}
 
 if (ambientModeEnabled) {
   process.stdout.write(
@@ -501,7 +510,7 @@ if (wakeMode !== "manual" && wakeMode !== "ambient") {
     );
     if (wakeMode === "wake-word") {
       process.stderr.write("Wake mode is strict wake-word. Exiting because setup failed.\n");
-      rl.close();
+      rl?.close();
       process.exitCode = 1;
       process.exit();
     }
@@ -523,7 +532,7 @@ if (wakeMode !== "manual" && wakeMode !== "ambient") {
     );
     if (wakeMode === "hotkey") {
       process.stderr.write("Wake mode is strict hotkey. Exiting because setup failed.\n");
-      rl.close();
+      rl?.close();
       process.exitCode = 1;
       process.exit();
     }
@@ -563,13 +572,37 @@ function stopAmbientLoop() {
 
 startAmbientLoop();
 
-for await (const line of rl) {
-  const cmd = line.trim().toLowerCase();
-  if (cmd === "q" || cmd === "quit" || cmd === "exit") {
-    break;
-  }
+let shouldShutdown = false;
+let resolveShutdownSignal;
+const shutdownSignal = new Promise((resolve) => {
+  resolveShutdownSignal = resolve;
+});
 
-  await runVoiceTurn("manual-enter");
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => {
+    shouldShutdown = true;
+    rl?.close();
+    resolveShutdownSignal();
+  });
+}
+
+if (wakeMode === "manual" && !rl) {
+  process.stderr.write("Wake mode 'manual' requires an interactive console (stdin TTY).\n");
+  shouldShutdown = true;
+  process.exitCode = 1;
+}
+
+if (rl && !shouldShutdown) {
+  for await (const line of rl) {
+    const cmd = line.trim().toLowerCase();
+    if (cmd === "q" || cmd === "quit" || cmd === "exit") {
+      break;
+    }
+
+    await runVoiceTurn("manual-enter");
+  }
+} else if (!shouldShutdown) {
+  await shutdownSignal;
 }
 
 for (const cleanup of cleanupFns) {
@@ -582,4 +615,4 @@ for (const cleanup of cleanupFns) {
 
 stopAmbientLoop();
 
-rl.close();
+rl?.close();

--- a/docs/desktop-client-walkthrough.md
+++ b/docs/desktop-client-walkthrough.md
@@ -110,6 +110,21 @@ VOICE_CLIENT_PLAY_COMMAND=powershell -NoProfile -NonInteractive -WindowStyle Hid
 
 On Windows, you can also leave `VOICE_CLIENT_PLAY_COMMAND` unset. The desktop client defaults to a hidden playback command and auto-rewrites legacy `Start-Process` values.
 
+### Windows background startup reliability
+
+If you launch the desktop client from a hidden/background session, prefer wake-word or ambient triggers instead of Enter-to-record.
+
+Recommended `.env` baseline for background startup:
+
+```dotenv
+VOICE_CLIENT_WAKE_MODE=auto
+VOICE_CLIENT_WAKE_WORD_ENABLED=true
+VOICE_CLIENT_HOTKEY_ENABLED=false
+VOICE_CLIENT_AMBIENT_MODE=false
+```
+
+Why: hidden sessions can have inconsistent keyboard/stdin behavior, while wake-word flow does not depend on interactive terminal input.
+
 If you want wake word support, choose a provider first:
 
 ### Option A — OpenWakeWord (free, no account required)

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -149,7 +149,7 @@ Skip this section unless you want cloud transcription via Azure Cognitive Servic
 | Variable | What it is | Example value | Needed for | Where to get it |
 | --- | --- | --- | --- | --- |
 | `TTS_PROVIDER` | Which text-to-speech engine to use first | `edge` | Spoken replies | Choose `edge`, `piper`, `elevenlabs`, or `auto` |
-| `TTS_FALLBACK_PROVIDER` | Backup TTS provider if the main one fails | `piper` | Edge with Piper fallback | Usually leave `piper` if you install Piper |
+| `TTS_FALLBACK_PROVIDER` | Backup TTS provider if the main one fails (`edge` or `piper`) | `piper` | Edge or ElevenLabs fallback | Usually leave `piper` if you install Piper |
 
 ## ElevenLabs TTS (advanced / optional)
 
@@ -159,7 +159,7 @@ Skip this section unless you want cloud-based ElevenLabs speech output.
 | --- | --- | --- | --- | --- |
 | `ELEVENLABS_API_KEY` | Your ElevenLabs API key | `sk_abc123...` | ElevenLabs output | [ElevenLabs dashboard](https://elevenlabs.io) |
 | `ELEVENLABS_VOICE_ID` | Voice to use for synthesis | `21m00Tcm4TlvDq8ikWAM` | ElevenLabs output | ElevenLabs voice library (default is "Rachel") |
-| `ELEVENLABS_MODEL` | Model ID for synthesis | `eleven_monolingual_v1` | ElevenLabs output | ElevenLabs docs — use `eleven_multilingual_v2` for non-English |
+| `ELEVENLABS_MODEL` | Model ID for synthesis | `eleven_multilingual_v2` | ElevenLabs output | ElevenLabs docs — recommended default that works across languages |
 
 ## Piper TTS (advanced / optional)
 
@@ -185,7 +185,7 @@ Skip this section unless you want Sonos playback.
 | `SONOS_RELAY_PI_URL` | Alias for the primary LAN or Raspberry Pi relay | `http://192.168.1.60:5005/play-audio` | Sonos playback | Your local Sonos relay service |
 | `SONOS_RELAY_FALLBACK_URL` | Secondary relay used if the primary fails | `http://192.168.1.61:5005/play-audio` | Sonos failover | Your backup relay service |
 | `SONOS_RELAY_AUTH_BEARER` | Optional auth token for the relay | `replace-with-relay-token-if-needed` | Protected Sonos relay | Your relay auth config |
-| `SONOS_RELAY_TIMEOUT_MS` | Timeout per relay attempt | `12000` | Sonos playback | Choose how long to wait before failover |
+| `SONOS_RELAY_TIMEOUT_MS` | Timeout per relay attempt | `30000` | Sonos playback | Choose how long to wait before failover |
 | `SONOS_ROOM_DEFAULT` | Default Sonos room when the request does not specify one | `Kitchen` | Sonos playback | Exact room name from your Sonos setup |
 | `SONOS_VPS_RELAY_PORT` | Port used by the in-repo Sonos relay service (`npm run sonos:relay`) | `8788` | In-repo relay deployment | Pick an open port on the relay host |
 | `SONOS_VPS_RELAY_PATH` | HTTP path that accepts voice-server relay payloads | `/play` | In-repo relay deployment | Keep default unless you need a custom route |

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -195,6 +195,8 @@ Skip this section unless you want Sonos playback.
 | `SONOS_RELAY_PUBLIC_BASE_URL` | Public/reachable base URL that Sonos uses to fetch temp audio clips from the relay | `http://192.168.1.50:8788` | In-repo relay deployment | Use an address reachable from Sonos speakers |
 | `SONOS_RELAY_MEDIA_TTL_MS` | How long temp relay audio files stay available before cleanup | `900000` | In-repo relay deployment | Usually keep 10 to 20 minutes |
 | `SONOS_RELAY_MAX_AUDIO_BYTES` | Max accepted payload size for relay audio uploads | `15728640` | In-repo relay deployment | Tune based on expected clip size |
+| `SONOS_RELAY_RESTORE_POLL_INTERVAL_MS` | Poll interval while waiting for spoken clip playback to finish before restore | `500` | In-repo relay deployment | Lower for quicker restore detection; higher for fewer SOAP calls |
+| `SONOS_RELAY_RESTORE_TIMEOUT_MS` | Maximum wait window before restoring prior source/volume regardless | `20000` | In-repo relay deployment | Set above your longest expected spoken reply |
 
 ## Desktop client
 

--- a/docs/sonos-vps-relay-service.md
+++ b/docs/sonos-vps-relay-service.md
@@ -76,6 +76,18 @@ Or with the npm script:
 npm run sonos:relay
 ```
 
+### Windows host reliability
+
+If your relay host is Windows, run the relay as a managed service wrapper (for example NSSM) instead of only relying on a user logon task.
+
+Recommended behavior:
+
+- start automatically at boot
+- restart on failure
+- run with the same `.env` values each time
+
+This avoids the common "works after login but later goes offline" relay pattern.
+
 ## systemd setup
 
 Copy the unit file and enable it:

--- a/docs/sonos-vps-relay-service.md
+++ b/docs/sonos-vps-relay-service.md
@@ -8,9 +8,10 @@ UPnP/AVTransport API.
 
 1. The voice server synthesises a TTS audio clip and POSTs it (base64-encoded) to this relay.
 2. The relay writes the clip to a temporary file and serves it over a short-lived HTTP URL.
-3. The relay calls the Sonos UPnP `SetAVTransportURI` + `Play` actions, pointing the speaker
-   at that URL.
-4. After `SONOS_RELAY_CLIP_TTL_MS` milliseconds the file is deleted automatically.
+3. The relay snapshots current Sonos transport URI/state and volume.
+4. The relay calls Sonos UPnP `SetAVTransportURI` + `Play`, pointing the speaker at the clip URL.
+5. After the clip finishes (or a timeout window), the relay restores prior source + playback state + volume.
+6. After `SONOS_RELAY_CLIP_TTL_MS` milliseconds the file is deleted automatically.
 
 ## Prerequisites
 
@@ -63,6 +64,8 @@ Both the Private network profile **and** the firewall rule are required. Either 
 | `SONOS_RELAY_PORT` | `8788` | Port this relay server listens on |
 | `SONOS_PORT` | `1400` | Sonos UPnP port |
 | `SONOS_RELAY_CLIP_TTL_MS` | `30000` | Milliseconds to keep the audio clip file before deleting it |
+| `SONOS_RELAY_RESTORE_POLL_INTERVAL_MS` | `500` | Milliseconds between Sonos transport-state polls while waiting for clip end |
+| `SONOS_RELAY_RESTORE_TIMEOUT_MS` | `20000` | Max milliseconds to wait for clip completion before forcing restore |
 
 ## Starting the relay
 
@@ -128,6 +131,6 @@ curl http://localhost:8788/health
 | Symptom | Check |
 |---|---|
 | `missing required env vars` on startup | Verify all three required vars are in `.env` |
-| `Sonos SOAP SetAVTransportURI failed (500)` | Confirm `SONOS_IP` and VPS → Sonos network path |
+| `Sonos SOAP AVTransport.SetAVTransportURI failed (500)` | Confirm `SONOS_IP` and VPS → Sonos network path |
 | Sonos does not play | Verify the Sonos speaker can reach `SONOS_RELAY_VPS_URL` — check `SONOS_RELAY_VPS_URL` is set to the correct VPS address from the Sonos device's perspective |
 | `Clip not found or expired` errors in logs | Increase `SONOS_RELAY_CLIP_TTL_MS` if Sonos is slow to fetch the clip |

--- a/docs/vps-deployment-guide.md
+++ b/docs/vps-deployment-guide.md
@@ -100,7 +100,7 @@ If you also want Sonos playback from this VPS deployment, add:
 - `SONOS_RELAY_URL=http://<relay-host>:<port>/<path>`
 - `SONOS_RELAY_AUTH_BEARER=<token>` (only if your relay requires auth)
 - `SONOS_RELAY_FALLBACK_URL=http://<backup-relay>:<port>/<path>` (optional)
-- `SONOS_RELAY_TIMEOUT_MS=12000` (recommended starting point)
+- `SONOS_RELAY_TIMEOUT_MS=30000` (recommended starting point)
 - `SONOS_ROOM_DEFAULT=<Exact Sonos room name>` (optional but useful)
 
 Why this matters: `systemd` does not activate your shell profile, so a plain `python3` may resolve to an interpreter that does not have `faster-whisper` installed.

--- a/src/server.js
+++ b/src/server.js
@@ -37,14 +37,14 @@ const piperNoiseW = process.env.PIPER_NOISE_W || "";
 const piperSentenceSilence = process.env.PIPER_SENTENCE_SILENCE || "";
 const elevenLabsApiKey = process.env.ELEVENLABS_API_KEY || "";
 const elevenLabsVoiceId = process.env.ELEVENLABS_VOICE_ID || "21m00Tcm4TlvDq8ikWAM";
-const elevenLabsModel = process.env.ELEVENLABS_MODEL || "eleven_monolingual_v1";
+const elevenLabsModel = process.env.ELEVENLABS_MODEL || "eleven_multilingual_v2";
 const ttsFallbackProvider = (process.env.TTS_FALLBACK_PROVIDER || "piper").trim().toLowerCase();
 const sttConfig = readSttConfigFromEnv(process.env);
 const transcribeAudio = createTranscriber(sttConfig);
 const sonosRelayUrl = process.env.SONOS_RELAY_URL || process.env.SONOS_RELAY_PI_URL || "";
 const sonosRelayFallbackUrl = process.env.SONOS_RELAY_FALLBACK_URL || "";
 const sonosRelayAuthBearer = process.env.SONOS_RELAY_AUTH_BEARER || "";
-const sonosRelayTimeoutMs = Number(process.env.SONOS_RELAY_TIMEOUT_MS || 12000);
+const sonosRelayTimeoutMs = Number(process.env.SONOS_RELAY_TIMEOUT_MS || 30000);
 const sonosRoomDefault = process.env.SONOS_ROOM_DEFAULT || "";
 
 const execFileAsync = promisify(execFile);
@@ -158,6 +158,11 @@ async function postToSonosRelay(relayUrl, body) {
       body: JSON.stringify(body),
       signal: controller.signal
     });
+  } catch (error) {
+    if (error && typeof error === "object" && "name" in error && error.name === "AbortError") {
+      throw new Error(`request timed out after ${sonosRelayTimeoutMs}ms`);
+    }
+    throw error;
   } finally {
     clearTimeout(timeout);
   }
@@ -299,26 +304,40 @@ async function synthesizeSpeech(text) {
   const preferred = ttsProvider;
   const fallback = ttsFallbackProvider;
 
+  async function synthesizeWithFallback(primaryProviderLabel, synthesizePrimary) {
+    try {
+      return await synthesizePrimary();
+    } catch (error) {
+      if (fallback !== "edge" && fallback !== "piper") {
+        throw error;
+      }
+
+      if (fallback === preferred) {
+        throw error;
+      }
+
+      process.stderr.write(
+        `${primaryProviderLabel} TTS failed, falling back to ${fallback}: ${error instanceof Error ? error.message : String(error)}\n`
+      );
+
+      if (fallback === "edge") {
+        return synthesizeSpeechWithEdge(cleanText);
+      }
+
+      return synthesizeSpeechWithPiper(cleanText);
+    }
+  }
+
   if (preferred === "piper") {
     return synthesizeSpeechWithPiper(cleanText);
   }
 
   if (preferred === "elevenlabs") {
-    return synthesizeSpeechWithElevenLabs(cleanText);
+    return synthesizeWithFallback("ElevenLabs", () => synthesizeSpeechWithElevenLabs(cleanText));
   }
 
   if (preferred === "edge") {
-    if (fallback === "piper") {
-      try {
-        return await synthesizeSpeechWithEdge(cleanText);
-      } catch (error) {
-        process.stderr.write(
-          `Edge TTS failed, falling back to Piper: ${error instanceof Error ? error.message : String(error)}\n`
-        );
-        return synthesizeSpeechWithPiper(cleanText);
-      }
-    }
-    return synthesizeSpeechWithEdge(cleanText);
+    return synthesizeWithFallback("Edge", () => synthesizeSpeechWithEdge(cleanText));
   }
 
   if (preferred === "auto") {

--- a/src/sonos-relay-lib.js
+++ b/src/sonos-relay-lib.js
@@ -10,14 +10,15 @@
  *
  * @param {string} action  - SOAP action name, e.g. "SetAVTransportURI"
  * @param {string} bodyXml - Inner XML fragment for the action body
+ * @param {string} service - Sonos service name, e.g. "AVTransport"
  * @returns {string} Full SOAP envelope string
  */
-export function buildSoapEnvelope(action, bodyXml) {
+export function buildSoapEnvelope(action, bodyXml, service = "AVTransport") {
   return `<?xml version="1.0" encoding="utf-8"?>
 <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
             s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
   <s:Body>
-    <u:${action} xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+    <u:${action} xmlns:u="urn:schemas-upnp-org:service:${service}:1">
       ${bodyXml}
     </u:${action}>
   </s:Body>
@@ -33,26 +34,40 @@ export function buildSoapEnvelope(action, bodyXml) {
  * @param {string} opts.action     - SOAP action name
  * @param {string} opts.bodyXml    - Inner XML for the action body
  * @param {Function} [opts.fetchImpl] - Optional fetch override for testing
- * @returns {Promise<void>}
+ * @returns {Promise<string>}
  */
 export async function sendSoapAction({ sonosIp, sonosPort = 1400, action, bodyXml, fetchImpl }) {
+  return sendSoapRequest({
+    sonosIp,
+    sonosPort,
+    action,
+    service: "AVTransport",
+    bodyXml,
+    fetchImpl
+  });
+}
+
+async function sendSoapRequest({ sonosIp, sonosPort = 1400, action, service, bodyXml, fetchImpl }) {
   const fetch_ = fetchImpl || globalThis.fetch;
-  const url = `http://${sonosIp}:${sonosPort}/MediaRenderer/AVTransport/Control`;
-  const envelope = buildSoapEnvelope(action, bodyXml);
+  const url = `http://${sonosIp}:${sonosPort}/MediaRenderer/${service}/Control`;
+  const envelope = buildSoapEnvelope(action, bodyXml, service);
+  const serviceType = `urn:schemas-upnp-org:service:${service}:1`;
 
   const response = await fetch_(url, {
     method: "POST",
     headers: {
       "Content-Type": "text/xml; charset=utf-8",
-      SOAPAction: `"urn:schemas-upnp-org:service:AVTransport:1#${action}"`
+      SOAPAction: `"${serviceType}#${action}"`
     },
     body: envelope
   });
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    throw new Error(`Sonos SOAP ${action} failed (${response.status}): ${text}`);
+    throw new Error(`Sonos SOAP ${service}.${action} failed (${response.status}): ${text}`);
   }
+
+  return response.text();
 }
 
 /**
@@ -67,10 +82,20 @@ export async function sendSoapAction({ sonosIp, sonosPort = 1400, action, bodyXm
  */
 export async function setSonosUri({ sonosIp, sonosPort, audioUrl, audioMimeType, fetchImpl }) {
   const metaXml = buildDidlLite(audioUrl, audioMimeType);
-  const escapedUrl = escapeXml(audioUrl);
-  const escapedMeta = escapeXml(metaXml);
+  return setSonosUriRaw({
+    sonosIp,
+    sonosPort,
+    uri: audioUrl,
+    metadata: metaXml,
+    fetchImpl
+  });
+}
 
-  await sendSoapAction({
+export async function setSonosUriRaw({ sonosIp, sonosPort, uri, metadata = "", fetchImpl }) {
+  const escapedUrl = escapeXml(uri);
+  const escapedMeta = escapeXml(metadata);
+
+  return sendSoapAction({
     sonosIp,
     sonosPort,
     action: "SetAVTransportURI",
@@ -97,6 +122,147 @@ export async function playSonos({ sonosIp, sonosPort, fetchImpl }) {
     bodyXml: `<InstanceID>0</InstanceID><Speed>1</Speed>`,
     fetchImpl
   });
+}
+
+export async function getSonosTransportInfo({ sonosIp, sonosPort, fetchImpl }) {
+  const xml = await sendSoapAction({
+    sonosIp,
+    sonosPort,
+    action: "GetTransportInfo",
+    bodyXml: `<InstanceID>0</InstanceID>`,
+    fetchImpl
+  });
+
+  return {
+    state: getXmlTag(xml, "CurrentTransportState") || null,
+    status: getXmlTag(xml, "CurrentTransportStatus") || null,
+    speed: getXmlTag(xml, "CurrentSpeed") || null
+  };
+}
+
+export async function getSonosMediaInfo({ sonosIp, sonosPort, fetchImpl }) {
+  const xml = await sendSoapAction({
+    sonosIp,
+    sonosPort,
+    action: "GetMediaInfo",
+    bodyXml: `<InstanceID>0</InstanceID>`,
+    fetchImpl
+  });
+
+  return {
+    currentUri: getXmlTag(xml, "CurrentURI") || null,
+    currentUriMetaData: getXmlTag(xml, "CurrentURIMetaData") || null
+  };
+}
+
+export async function getSonosVolume({ sonosIp, sonosPort, fetchImpl }) {
+  const xml = await sendSoapRequest({
+    sonosIp,
+    sonosPort,
+    service: "RenderingControl",
+    action: "GetVolume",
+    bodyXml: `<InstanceID>0</InstanceID><Channel>Master</Channel>`,
+    fetchImpl
+  });
+  const value = Number(getXmlTag(xml, "CurrentVolume"));
+  return Number.isFinite(value) ? value : null;
+}
+
+export async function setSonosVolume({ sonosIp, sonosPort, volume, fetchImpl }) {
+  const bounded = Math.max(0, Math.min(100, Number(volume)));
+  return sendSoapRequest({
+    sonosIp,
+    sonosPort,
+    service: "RenderingControl",
+    action: "SetVolume",
+    bodyXml: `<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>${bounded}</DesiredVolume>`,
+    fetchImpl
+  });
+}
+
+export async function playClipWithRestore({
+  sonosIp,
+  sonosPort,
+  clipUrl,
+  audioMimeType,
+  fetchImpl,
+  pollIntervalMs = 500,
+  pollTimeoutMs = 20000
+}) {
+  const snapshot = {
+    media: await getSonosMediaInfo({ sonosIp, sonosPort, fetchImpl }),
+    transport: await getSonosTransportInfo({ sonosIp, sonosPort, fetchImpl }),
+    volume: await getSonosVolume({ sonosIp, sonosPort, fetchImpl })
+  };
+
+  await setSonosUri({ sonosIp, sonosPort, audioUrl: clipUrl, audioMimeType, fetchImpl });
+  await playSonos({ sonosIp, sonosPort, fetchImpl });
+
+  await waitForClipEnd({ sonosIp, sonosPort, clipUrl, fetchImpl, pollIntervalMs, pollTimeoutMs });
+
+  if (snapshot.media.currentUri) {
+    await setSonosUriRaw({
+      sonosIp,
+      sonosPort,
+      uri: snapshot.media.currentUri,
+      metadata: snapshot.media.currentUriMetaData || "",
+      fetchImpl
+    });
+  }
+  if (snapshot.transport.state === "PLAYING") {
+    await playSonos({ sonosIp, sonosPort, fetchImpl });
+  }
+  if (snapshot.volume !== null) {
+    await setSonosVolume({ sonosIp, sonosPort, volume: snapshot.volume, fetchImpl });
+  }
+
+  return {
+    previousUri: snapshot.media.currentUri,
+    previousState: snapshot.transport.state,
+    previousVolume: snapshot.volume
+  };
+}
+
+async function waitForClipEnd({
+  sonosIp,
+  sonosPort,
+  clipUrl,
+  fetchImpl,
+  pollIntervalMs,
+  pollTimeoutMs
+}) {
+  const start = Date.now();
+  while (Date.now() - start < pollTimeoutMs) {
+    const [media, transport] = await Promise.all([
+      getSonosMediaInfo({ sonosIp, sonosPort, fetchImpl }),
+      getSonosTransportInfo({ sonosIp, sonosPort, fetchImpl })
+    ]);
+
+    if (media.currentUri !== clipUrl || transport.state === "STOPPED") {
+      return;
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function getXmlTag(xml, tag) {
+  const match = String(xml || "").match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, "i"));
+  return match ? unescapeXml(match[1]) : null;
+}
+
+function unescapeXml(value) {
+  return String(value)
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&amp;/g, "&");
 }
 
 /**

--- a/src/sonos-relay-server.js
+++ b/src/sonos-relay-server.js
@@ -17,6 +17,8 @@
  *   SONOS_RELAY_PORT            - listening port (default 8788)
  *   SONOS_PORT                  - Sonos UPnP port (default 1400)
  *   SONOS_RELAY_CLIP_TTL_MS     - ms to keep the temp audio file (default 30000)
+ *   SONOS_RELAY_RESTORE_POLL_INTERVAL_MS - restore poll cadence (default 500)
+ *   SONOS_RELAY_RESTORE_TIMEOUT_MS       - max restore wait window (default 20000)
  */
 
 import fs from "node:fs";
@@ -27,7 +29,7 @@ import crypto from "node:crypto";
 import dotenv from "dotenv";
 import express from "express";
 
-import { setSonosUri, playSonos } from "./sonos-relay-lib.js";
+import { playClipWithRestore } from "./sonos-relay-lib.js";
 
 dotenv.config();
 
@@ -42,6 +44,8 @@ const SONOS_IP = process.env.SONOS_IP;
 const SONOS_PORT = Number(process.env.SONOS_PORT || 1400);
 const VPS_BASE_URL = process.env.SONOS_RELAY_VPS_URL.replace(/\/$/, "");
 const CLIP_TTL_MS = Number(process.env.SONOS_RELAY_CLIP_TTL_MS || 30000);
+const RESTORE_POLL_INTERVAL_MS = Number(process.env.SONOS_RELAY_RESTORE_POLL_INTERVAL_MS || 500);
+const RESTORE_POLL_TIMEOUT_MS = Number(process.env.SONOS_RELAY_RESTORE_TIMEOUT_MS || 20000);
 const BEARER_TOKEN = process.env.SONOS_RELAY_BEARER_TOKEN;
 
 // Temp directory for audio clips
@@ -152,23 +156,21 @@ app.post("/play-audio", requireBearer, async (req, res) => {
       fs.promises.unlink(filePath).catch(() => {});
     }, CLIP_TTL_MS);
 
-    await setSonosUri({
+    const restore = await playClipWithRestore({
       sonosIp: SONOS_IP,
       sonosPort: SONOS_PORT,
-      audioUrl: clipUrl,
-      audioMimeType
-    });
-
-    await playSonos({
-      sonosIp: SONOS_IP,
-      sonosPort: SONOS_PORT
+      clipUrl,
+      audioMimeType,
+      pollIntervalMs: RESTORE_POLL_INTERVAL_MS,
+      pollTimeoutMs: RESTORE_POLL_TIMEOUT_MS
     });
 
     res.json({
       ok: true,
       room: room || null,
       clipUrl,
-      sonosIp: SONOS_IP
+      sonosIp: SONOS_IP,
+      restore
     });
   } catch (error) {
     // Best-effort cleanup on failure

--- a/test/sonos-relay.test.js
+++ b/test/sonos-relay.test.js
@@ -5,7 +5,8 @@ import {
   buildSoapEnvelope,
   escapeXml,
   setSonosUri,
-  playSonos
+  playSonos,
+  playClipWithRestore
 } from "../src/sonos-relay-lib.js";
 
 test("escapeXml handles all special characters", () => {
@@ -86,7 +87,7 @@ test("setSonosUri rejects when Sonos returns non-2xx status", async () => {
         audioMimeType: "audio/mpeg",
         fetchImpl: mockFetch
       }),
-    /Sonos SOAP SetAVTransportURI failed \(500\)/
+    /Sonos SOAP AVTransport\.SetAVTransportURI failed \(500\)/
   );
 });
 
@@ -108,5 +109,84 @@ test("setSonosUri escapes special chars in audio URL", async () => {
   assert.ok(
     calls[0].opts.body.includes("&amp;"),
     "URL ampersand should be XML-escaped in SOAP body"
+  );
+});
+
+test("playClipWithRestore restores prior source, play state, and volume", async () => {
+  const clipUrl = "http://10.0.0.1:8788/clips/test.mp3";
+  const expected = [
+    {
+      service: "AVTransport",
+      action: "GetMediaInfo",
+      xml: "<CurrentURI>x-sonos-htastream:RINCON_TEST:spdif</CurrentURI><CurrentURIMetaData>&lt;meta&gt;tv&lt;/meta&gt;</CurrentURIMetaData>"
+    },
+    {
+      service: "AVTransport",
+      action: "GetTransportInfo",
+      xml: "<CurrentTransportState>PLAYING</CurrentTransportState><CurrentTransportStatus>OK</CurrentTransportStatus><CurrentSpeed>1</CurrentSpeed>"
+    },
+    {
+      service: "RenderingControl",
+      action: "GetVolume",
+      xml: "<CurrentVolume>18</CurrentVolume>"
+    },
+    { service: "AVTransport", action: "SetAVTransportURI", xml: "" },
+    { service: "AVTransport", action: "Play", xml: "" },
+    {
+      service: "AVTransport",
+      action: "GetMediaInfo",
+      xml: `<CurrentURI>${clipUrl}</CurrentURI><CurrentURIMetaData></CurrentURIMetaData>`
+    },
+    {
+      service: "AVTransport",
+      action: "GetTransportInfo",
+      xml: "<CurrentTransportState>PLAYING</CurrentTransportState>"
+    },
+    {
+      service: "AVTransport",
+      action: "GetMediaInfo",
+      xml: `<CurrentURI>${clipUrl}</CurrentURI><CurrentURIMetaData></CurrentURIMetaData>`
+    },
+    {
+      service: "AVTransport",
+      action: "GetTransportInfo",
+      xml: "<CurrentTransportState>STOPPED</CurrentTransportState>"
+    },
+    { service: "AVTransport", action: "SetAVTransportURI", xml: "" },
+    { service: "AVTransport", action: "Play", xml: "" },
+    { service: "RenderingControl", action: "SetVolume", xml: "" }
+  ];
+
+  const calls = [];
+  const mockFetch = async (_url, opts) => {
+    const soapAction = String(opts.headers.SOAPAction || "");
+    const match = soapAction.match(/service:([^:]+):1#([^\"]+)/);
+    const service = match ? match[1] : null;
+    const action = match ? match[2] : null;
+    const next = expected.shift();
+    assert.ok(next, `unexpected SOAP request ${service}.${action}`);
+    assert.equal(service, next.service);
+    assert.equal(action, next.action);
+    calls.push({ service, action, body: String(opts.body || "") });
+    return { ok: true, text: async () => `<Response>${next.xml}</Response>` };
+  };
+
+  const result = await playClipWithRestore({
+    sonosIp: "192.168.4.33",
+    sonosPort: 1400,
+    clipUrl,
+    audioMimeType: "audio/mpeg",
+    fetchImpl: mockFetch,
+    pollIntervalMs: 0,
+    pollTimeoutMs: 2000
+  });
+
+  assert.equal(expected.length, 0);
+  assert.equal(result.previousUri, "x-sonos-htastream:RINCON_TEST:spdif");
+  assert.equal(result.previousState, "PLAYING");
+  assert.equal(result.previousVolume, 18);
+  assert.ok(
+    calls.some((call) => call.action === "SetVolume" && call.body.includes("<DesiredVolume>18</DesiredVolume>")),
+    "restore should set previous volume"
   );
 });


### PR DESCRIPTION
## Summary
- make desktop/client.js tolerant of non-interactive stdin so hidden/background Windows launches no longer depend on readline or Enter prompts
- extend server-side TTS fallback behavior (including ElevenLabs fallback) and improve Sonos relay timeout handling plus timeout error clarity
- update env/docs guidance for desktop background mode and more durable Sonos relay runtime defaults (including Windows service guidance)

## Test notes
- npm test